### PR TITLE
Add cache for CI

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,8 +18,19 @@ jobs:
     - name: Install NodeJS
       uses: actions/setup-node@v1.1.0
 
+    # Cache layer for project dependencies
+    - name: Cache Dependencies
+      id: cache-dependencies
+      uses: actions/cache@v1
+      env:
+        cache-name: mosaic-dependencies
+      with:
+        path: ~/.npm
+        key: package-lock-${{ hashFiles('**/package-lock.json') }}
+
     # Install project dependencies
     - name: Install Dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: npm ci
     
     # Run tests in CI mode

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # @melfore/mosaic
 Melfore's UI kit library based on `@material-ui`
 
+![Mosaic CI](https://github.com/melfore/mosaic/workflows/Mosaic%20CI/badge.svg)
+
 ## Usage
 Add the package to your project with:
 

--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -31,7 +31,7 @@ describe('Button test suite:', () => {
     expect(buttonLabel.text()).toEqual(defaultProps.label);
   })
 
-  it('failing test', () => {
+  xit('failing test', () => {
     const onClickHandler = jest.fn();
     const component = componentWrapper({
       onClick: onClickHandler,


### PR DESCRIPTION
This PR fixes #6 adding a cache layer on the Mosaic CI for package dependencies.
In this way the CI can execute faster if there are no changes to the `package.json` file.
I've also added the status badge in README file that will reflect latest build status for Mosaic.

I've disabled the failing test for the `Button` component in order to let CI go through all steps. 
I'll use it later for developing other CI features that need a previous step failing, then I'll permanently delete the fake test.

We don't have to worry about number of CI runs triggered, as GitHub automatically handles cache limit and expire.
> GitHub will remove any cache entries that have not been accessed in over 7 days. There is no limit on the number of caches you can store, but the total size of all caches in a repository is limited to 5 GB. If you exceed this limit, GitHub will save your cache but will begin evicting caches until the total size is less than 5 GB.