### PR TITLE
Improve end user documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,66 +39,65 @@ We use `VSCode` type-based snippets in order to speed up the development process
 #### New Component
 
 ```
-  "TSReactComponent": {
-    "prefix": "New Component",
-    "body": [
-      "import React, { FC } from 'react';",
-      "import MUI$1 from '@material-ui/core/$1';",
-      "",
-      "interface $2 {",
-      "",
-      "}",
-      "",
-      "/**",
-      " * $3 component made on top of `@material-ui/core/$1`.",
-      " * ",
-      " * Add required documentation, use HTML tags if needed.",
-      " */",
-      "const $3: FC<$2> = ({}) => {",
-      "  return null;",
-      "};",
-      "",
-      "export default $3;",
-      "",
-    ],
-    "description": "Snippet for a new TSReact Component"
-  }
+	"TSReactComponent": {
+		"prefix": "New Component",
+		"body": [
+			"import React, { FC } from 'react';",
+			"import MUI$1 from '@material-ui/core/$1';",
+			"",
+			"// TODO: move this in a dedicated file into /types",
+			"interface $2 {",
+			"",
+			"}",
+			"",
+			"/**",
+			" * $3 component made on top of `@material-ui/core/$1`",
+			" */",
+			"const $3: FC<$2> = ({}) => {",
+			"  return null;",
+			"};",
+			"",
+			"export default $3;",
+			"",
+		],
+		"description": "Snippet for a new TSReact Component"
+	}
 ```
 
 #### New Story
 
 ```
-  "TSReactStory": {
-    "prefix": "New Story",
-    "body": [
-      "import React from 'react';",
-      "import {  } from '@storybook/addon-actions';",
-      "import {  } from '@storybook/addon-knobs';",
-      "import {  } from '../../types/$1';",
-      "import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from '../../utils/stories';",
-      "import $2 from '.';",
-      "",
-      "export default {",
-      "  title: '$2',",
-      "  component: $2,",
-      "  parameters: {",
-      "    ...DOCS_PAGE_STRUCTURE,",
-      "  },",
-      "}",
-      "",
-      "export const Canvas = () => (",
-      "  <$2 />",
-      ");",
-      "",
-      "export const OtherStories = () => (",
-      "  <StoriesWrapper>",
-      "    <$2 />",
-      "  </StoriesWrapper>",
-      ");",
-      "",
-    ],
-    "description": "Snippet for a new TSReact story"
-  }
+	"TSReactStory": {
+		"prefix": "New Story",
+		"body": [
+			"import React from 'react';",
+			"import {  } from '@storybook/addon-actions';",
+			"import {  } from '@storybook/addon-knobs';",
+			"import {  } from '../../types/$1';",
+			"import { getDocsPageStructure, StoriesWrapper } from '../../utils/stories';",
+			"import $1 from '.';",
+			"",
+			"export default {",
+			"  title: '$1',",
+			"  component: $1,",
+			"  parameters: {",
+			"    ...getDocsPageStructure('$1'),",
+			"  },",
+			"}",
+			"",
+			"export const Canvas = () => (",
+			"  <$1 />",
+			");",
+			"",
+			"export const OtherStories = () => (",
+			"  <StoriesWrapper>",
+			"    <$1 />",
+			"  </StoriesWrapper>",
+			");",
+			"",
+		],
+		"description": "Snippet for a new TSReact story"
+	}
 ```
 
 #### New Test

--- a/src/components/Button/index.stories.tsx
+++ b/src/components/Button/index.stories.tsx
@@ -4,14 +4,14 @@ import { boolean, object, select, text } from "@storybook/addon-knobs";
 import { ButtonIconPosition, ButtonVariants } from "../../types/Button";
 import { Icons } from "../../types/Icon";
 import IntlProviderMock, { LocaleMock, MessageMock } from "../../utils/mocks/IntlProviderMock";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Button, { ButtonIntl } from ".";
 
 export default {
   title: "Button",
   component: Button,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("Button"),
   },
 };
 

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -28,9 +28,6 @@ const getIcons = (dataCy: string, iconConfig?: ButtonIconType) => {
 
 /**
  * Button component made on top of `@material-ui/core/Button`.
- *
- * Supports usage inside `IntlProvider` context of `react-intl` using `ButtonIntl` exported version.
- * For more details have a look <a href="/docs/button--with-intl">here</a>
  */
 const Button: FC<ButtonType> = ({
   dataCy = "button",

--- a/src/components/Checkbox/index.stories.tsx
+++ b/src/components/Checkbox/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import { boolean, text, optionsKnob as options, select } from "@storybook/addon-knobs";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Checkbox from ".";
 import { CheckboxSize } from "../../types/Checkbox";
 
@@ -9,7 +9,7 @@ export default {
   title: "Checkbox",
   component: Checkbox,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("Checkbox", ["usage", "canvas"]),
   },
 };
 

--- a/src/components/Checkbox/index.stories.tsx
+++ b/src/components/Checkbox/index.stories.tsx
@@ -4,6 +4,7 @@ import { boolean, text, optionsKnob as options, select } from "@storybook/addon-
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Checkbox from ".";
 import { CheckboxSize } from "../../types/Checkbox";
+import FormMock from "../../utils/mocks/FormMock";
 
 export default {
   title: "Checkbox",
@@ -14,15 +15,19 @@ export default {
 };
 
 export const Canvas = () => (
-  <Checkbox
-    dataCy={text("data-cy", "checkbox-identifier")}
-    value={boolean("value", false)}
-    onChange={action("Change checkbox")}
-    required={boolean("value", false)}
-    size={select("size", CheckboxSize, CheckboxSize.small, CheckboxSize.default)}
-    disabled={boolean("disabled", false)}
-    intermediate={boolean("intermediate", false)}
-  />
+  // FormMock simulates external form component handling state
+  // In a real case scenario "onChange" and "value" props must be passed to InputNumber
+  <FormMock inputValue={boolean("value", true)} onInputChange={action("Change checkbox")}>
+    <Checkbox
+      dataCy={text("data-cy", "checkbox-identifier")}
+      value={boolean("value", true)}
+      onChange={action("Change checkbox")}
+      required={boolean("value", false)}
+      size={select("size", CheckboxSize, CheckboxSize.small, CheckboxSize.default)}
+      disabled={boolean("disabled", false)}
+      intermediate={boolean("intermediate", false)}
+    />
+  </FormMock>
 );
 
 export const Values = () => (

--- a/src/components/Checkbox/index.stories.tsx
+++ b/src/components/Checkbox/index.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: "Checkbox",
   component: Checkbox,
   parameters: {
-    ...getDocsPageStructure("Checkbox", ["usage", "canvas"]),
+    ...getDocsPageStructure("Checkbox", false),
   },
 };
 

--- a/src/components/Checkbox/index.stories.tsx
+++ b/src/components/Checkbox/index.stories.tsx
@@ -16,7 +16,7 @@ export default {
 
 export const Canvas = () => (
   // FormMock simulates external form component handling state
-  // In a real case scenario "onChange" and "value" props must be passed to InputNumber
+  // In a real case scenario "onChange" and "value" props must be passed to Checkbox
   <FormMock inputValue={boolean("value", true)} onInputChange={action("Change checkbox")}>
     <Checkbox
       dataCy={text("data-cy", "checkbox-identifier")}

--- a/src/components/Icon/index.stories.tsx
+++ b/src/components/Icon/index.stories.tsx
@@ -9,7 +9,7 @@ export default {
   title: "Icon",
   component: Icon,
   parameters: {
-    ...getDocsPageStructure("Icon", ["usage", "canvas"]),
+    ...getDocsPageStructure("Icon", false),
   },
 };
 

--- a/src/components/Icon/index.stories.tsx
+++ b/src/components/Icon/index.stories.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import {} from "@storybook/addon-actions";
 import { select } from "@storybook/addon-knobs";
 import { Icons, IconSize } from "../../types/Icon";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Icon from ".";
 
 export default {
   title: "Icon",
   component: Icon,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("Icon", ["usage", "canvas"]),
   },
 };
 

--- a/src/components/InputNumber/index.stories.tsx
+++ b/src/components/InputNumber/index.stories.tsx
@@ -4,14 +4,14 @@ import { boolean, select, number, text } from "@storybook/addon-knobs";
 import { InputSize, InputVariant } from "../../types/Input";
 import FormMock from "../../utils/mocks/FormMock";
 import IntlProviderMock, { LocaleMock, MessageMock } from "../../utils/mocks/IntlProviderMock";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import InputNumber, { InputNumberIntl } from ".";
 
 export default {
   title: "InputNumber",
   component: InputNumber,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("InputNumber"),
   },
 };
 

--- a/src/components/InputNumber/index.tsx
+++ b/src/components/InputNumber/index.tsx
@@ -30,8 +30,6 @@ const getNumericValue = (value: string, options: any): number | null => {
 
 /**
  * InputNumber component made on top of `@material-ui/core/TextField`
- *
- * Supports usage inside `IntlProvider` context of `react-intl` using `InputNumberIntl` exported version.
  */
 const InputNumber: FC<InputNumberType> = ({
   dataCy,

--- a/src/components/InputText/index.stories.tsx
+++ b/src/components/InputText/index.stories.tsx
@@ -3,14 +3,14 @@ import { action } from "@storybook/addon-actions";
 import { boolean, text, object, select } from "@storybook/addon-knobs";
 import { InputSize, InputVariant } from "../../types/Input";
 import IntlProviderMock, { LocaleMock, MessageMock } from "../../utils/mocks/IntlProviderMock";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import InputText, { InputTextIntl } from ".";
 
 export default {
   title: "InputText",
   component: InputText,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("InputText"),
   },
 };
 

--- a/src/components/InputText/index.tsx
+++ b/src/components/InputText/index.tsx
@@ -19,8 +19,6 @@ const getMultilineProps = (multiline?: MultilineInputType) => {
 
 /**
  * InputText component made on top of `@material-ui/core/TextField`
- *
- * Supports usage inside `IntlProvider` context of `react-intl` using `InputTextIntl` exported version.
  **/
 const InputText: FC<InputTextType> = ({
   dataCy,

--- a/src/components/Modal/index.stories.tsx
+++ b/src/components/Modal/index.stories.tsx
@@ -3,7 +3,7 @@ import { action } from "@storybook/addon-actions";
 import { text, object, boolean, select } from "@storybook/addon-knobs";
 import { ButtonVariants } from "../../types/Button";
 import ModalMock from "../../utils/mocks/ModalMock";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Modal, { ModalIntl } from ".";
 import IntlProviderMock, { LocaleMock, MessageMock } from "../../utils/mocks/IntlProviderMock";
 
@@ -11,7 +11,7 @@ export default {
   title: "Modal",
   component: Modal,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("Modal"),
   },
 };
 

--- a/src/components/Switch/index.stories.tsx
+++ b/src/components/Switch/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
 import { boolean, text } from "@storybook/addon-knobs";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Switch from ".";
 import { SwitchSize } from "../../types/Switch";
 
@@ -9,7 +9,7 @@ export default {
   title: "Switch",
   component: Switch,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("Switch", ["usage", "canvas"]),
   },
 };
 

--- a/src/components/Switch/index.stories.tsx
+++ b/src/components/Switch/index.stories.tsx
@@ -4,6 +4,7 @@ import { boolean, text } from "@storybook/addon-knobs";
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Switch from ".";
 import { SwitchSize } from "../../types/Switch";
+import FormMock from "../../utils/mocks/FormMock";
 
 export default {
   title: "Switch",
@@ -14,11 +15,15 @@ export default {
 };
 
 export const Canvas = () => (
-  <Switch
-    dataCy={text("data-cy", "switch-identifier")}
-    value={boolean("value", false)}
-    onChange={action("Change switch")}
-  />
+  // FormMock simulates external form component handling state
+  // In a real case scenario "onChange" and "value" props must be passed to Switch
+  <FormMock inputValue={boolean("value", true)} onInputChange={action("Change switch")}>
+    <Switch
+      dataCy={text("data-cy", "switch-identifier")}
+      value={boolean("value", true)}
+      onChange={action("Change switch")}
+    />
+  </FormMock>
 );
 
 export const Values = () => (

--- a/src/components/Switch/index.stories.tsx
+++ b/src/components/Switch/index.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: "Switch",
   component: Switch,
   parameters: {
-    ...getDocsPageStructure("Switch", ["usage", "canvas"]),
+    ...getDocsPageStructure("Switch", false),
   },
 };
 

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -6,7 +6,7 @@ import { SwitchType, SwitchSize } from "../../types/Switch";
 import withIntl from "../../utils/hocs/withIntl";
 
 /**
- * Switch component made on top of `@material-ui/core/Switch
+ * Switch component made on top of `@material-ui/core/Switch`.
  */
 const Switch: FC<SwitchType> = ({
   dataCy,

--- a/src/components/Typography/index.stories.tsx
+++ b/src/components/Typography/index.stories.tsx
@@ -3,14 +3,14 @@ import {} from "@storybook/addon-actions";
 import { text, select, boolean } from "@storybook/addon-knobs";
 import { TypographyVariants } from "../../types/Typography";
 import IntlProviderMock, { LocaleMock, MessageMock } from "../../utils/mocks/IntlProviderMock";
-import { DOCS_PAGE_STRUCTURE, StoriesWrapper } from "../../utils/stories";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Typography, { TypographyIntl } from ".";
 
 export default {
   title: "Typography",
   component: Typography,
   parameters: {
-    ...DOCS_PAGE_STRUCTURE,
+    ...getDocsPageStructure("Typography"),
   },
 };
 

--- a/src/components/Typography/index.stories.tsx
+++ b/src/components/Typography/index.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Fragment } from "react";
 import {} from "@storybook/addon-actions";
 import { text, select, boolean } from "@storybook/addon-knobs";
 import { TypographyVariants } from "../../types/Typography";
@@ -10,7 +10,21 @@ export default {
   title: "Typography",
   component: Typography,
   parameters: {
-    ...getDocsPageStructure("Typography"),
+    ...getDocsPageStructure("Typography", true, {
+      title: "Testing with cypress",
+      subtitle: true,
+      body: (
+        <Fragment>
+          <p>
+            The implementation offered by <code>@material-ui</code> doesn't support dataCy attribute. The value of the
+            <code>dataCy</code> property is being used by <code>className</code> with the <code>data-cy-</code> prefix.
+          </p>
+          <p>
+            Example: passing <code>dataCy="typography"</code> results in <code>className="data-cy-typography"</code>.
+          </p>
+        </Fragment>
+      ),
+    }),
   },
 };
 

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -6,18 +6,7 @@ import withIntl from "../../utils/hocs/withIntl";
 import { getBottomSpacing, getTruncate, VARIANT_COMPONENT_MAP } from "./utils";
 
 /**
- * Typography component made on top of `@material-ui/core/Typography`.<br />
- * Usage: `import { Typography } from "@melfore/mosaic";`
- *
- * <b>Support for `react-intl`</b>
- * Supports usage inside `IntlProvider` context of `react-intl` using `TypographyIntl` exported version.<br />
- * Instead of passing `label` prop, provide `labelId` prop with the key-string to translate.<br />
- * Usage: `import { TypographyIntl } from "@melfore/mosaic";`
- *
- * <b>Testing with `cypress`</b>
- * The implementation offered by `@material-ui` doesn't support `dataCy` attribute.<br />
- * The value of the `dataCy` property is being used by `className` with the `data-cy-` prefix.<br />
- * Example: passing `dataCy="typography"` results in `className="data-cy-typography"`.
+ * Typography component made on top of `@material-ui/core/Typography`.
  */
 const Typography: FC<TypographyType> = ({
   bottomSpacing = undefined,

--- a/src/utils/stories/CustomDocsBlocks.tsx
+++ b/src/utils/stories/CustomDocsBlocks.tsx
@@ -1,0 +1,26 @@
+import React, { FC, Fragment, ReactElement } from "react";
+import { CUSTOM_BODY_CLASS, CUSTOM_TITLES_CLASS } from "./utils";
+
+interface CustomDocsTitleType {
+  title: string;
+  subtitle?: boolean;
+}
+
+export const CustomDocsTitle: FC<CustomDocsTitleType> = ({ subtitle = false, title }) => {
+  return subtitle ? <h3 className={CUSTOM_TITLES_CLASS}>{title}</h3> : <h2 className={CUSTOM_TITLES_CLASS}>{title}</h2>;
+};
+
+interface CustomDocsBlockType {
+  body: ReactElement;
+  subtitle?: boolean;
+  title: string;
+}
+
+export const CustomDocsBlock: FC<CustomDocsBlockType> = ({ body, subtitle, title }) => {
+  return (
+    <Fragment>
+      <CustomDocsTitle subtitle={subtitle} title={title} />
+      <div className={CUSTOM_BODY_CLASS}>{body}</div>
+    </Fragment>
+  );
+};

--- a/src/utils/stories/CustomDocsPage.jsx
+++ b/src/utils/stories/CustomDocsPage.jsx
@@ -10,6 +10,7 @@ export default class CustomDocsPage extends PureComponent {
     name: PropTypes.string.isRequired,
     notes: PropTypes.shape({
       body: PropTypes.element.isRequired,
+      subtitle: PropTypes.bool,
       title: PropTypes.string.isRequired,
     }),
   };

--- a/src/utils/stories/CustomDocsPage.jsx
+++ b/src/utils/stories/CustomDocsPage.jsx
@@ -1,0 +1,60 @@
+import React, { Fragment, PureComponent } from "react";
+import PropTypes from "prop-types";
+import { Description, Primary, Props, Stories, Subtitle, Title } from "@storybook/addon-docs/blocks";
+import { CustomDocsBlock, CustomDocsTitle } from "./CustomDocsBlocks";
+import { DEFAULT_BLOCKS, DOCS_PAGE_STYLE, INVALID_COMPONENT_BLOCKS_ERROR, MISSING_COMPONENT_NAME_ERROR } from "./utils";
+
+export default class CustomDocsPage extends PureComponent {
+  static propTypes = {
+    blocks: PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.oneOf[("usage", "intl", "notes", "canvas")],
+        PropTypes.shape({
+          body: PropTypes.element.isRequired,
+          title: PropTypes.string.isRequired,
+        }),
+      ])
+    ),
+    name: PropTypes.string.isRequired,
+  };
+
+  static defaultProps = {
+    blocks: ["usage", "intl", "canvas"],
+  };
+
+  constructor(props) {
+    super(props);
+    const { blocks, name } = props;
+    if (!name) {
+      throw new Error(MISSING_COMPONENT_NAME_ERROR);
+    }
+
+    if (!blocks) {
+      throw new Error(INVALID_COMPONENT_BLOCKS_ERROR);
+    }
+  }
+
+  render() {
+    const { blocks, name } = this.props;
+    const defaultBlocks = DEFAULT_BLOCKS(name);
+    return (
+      <Fragment>
+        <style
+          dangerouslySetInnerHTML={{
+            __html: DOCS_PAGE_STYLE,
+          }}
+        />
+        <Title />
+        <Subtitle />
+        <Description />
+        {blocks.map((block) => (
+          <CustomDocsBlock {...defaultBlocks[block]} />
+        ))}
+        <Primary />
+        <Stories />
+        <CustomDocsTitle title="Props" />
+        <Props />
+      </Fragment>
+    );
+  }
+}

--- a/src/utils/stories/CustomDocsPage.jsx
+++ b/src/utils/stories/CustomDocsPage.jsx
@@ -2,40 +2,33 @@ import React, { Fragment, PureComponent } from "react";
 import PropTypes from "prop-types";
 import { Description, Primary, Props, Stories, Subtitle, Title } from "@storybook/addon-docs/blocks";
 import { CustomDocsBlock, CustomDocsTitle } from "./CustomDocsBlocks";
-import { DEFAULT_BLOCKS, DOCS_PAGE_STYLE, INVALID_COMPONENT_BLOCKS_ERROR, MISSING_COMPONENT_NAME_ERROR } from "./utils";
+import { DEFAULT_BLOCKS, DOCS_PAGE_STYLE, MISSING_COMPONENT_NAME_ERROR } from "./utils";
 
 export default class CustomDocsPage extends PureComponent {
   static propTypes = {
-    blocks: PropTypes.arrayOf(
-      PropTypes.oneOfType([
-        PropTypes.oneOf[("usage", "intl", "notes", "canvas")],
-        PropTypes.shape({
-          body: PropTypes.element.isRequired,
-          title: PropTypes.string.isRequired,
-        }),
-      ])
-    ),
+    intlSupport: PropTypes.bool,
     name: PropTypes.string.isRequired,
+    notes: PropTypes.shape({
+      body: PropTypes.element.isRequired,
+      title: PropTypes.string.isRequired,
+    }),
   };
 
   static defaultProps = {
-    blocks: ["usage", "intl", "canvas"],
+    intlSupport: true,
+    notes: null,
   };
 
   constructor(props) {
     super(props);
-    const { blocks, name } = props;
+    const { name } = props;
     if (!name) {
       throw new Error(MISSING_COMPONENT_NAME_ERROR);
-    }
-
-    if (!blocks) {
-      throw new Error(INVALID_COMPONENT_BLOCKS_ERROR);
     }
   }
 
   render() {
-    const { blocks, name } = this.props;
+    const { intlSupport, name, notes } = this.props;
     const defaultBlocks = DEFAULT_BLOCKS(name);
     return (
       <Fragment>
@@ -47,9 +40,10 @@ export default class CustomDocsPage extends PureComponent {
         <Title />
         <Subtitle />
         <Description />
-        {blocks.map((block) => (
-          <CustomDocsBlock {...defaultBlocks[block]} />
-        ))}
+        <CustomDocsBlock {...defaultBlocks["usage"]} />
+        {intlSupport && <CustomDocsBlock {...defaultBlocks["intl"]} />}
+        {!!notes && <CustomDocsBlock {...notes} />}
+        <CustomDocsBlock {...defaultBlocks["canvas"]} />
         <Primary />
         <Stories />
         <CustomDocsTitle title="Props" />

--- a/src/utils/stories/index.jsx
+++ b/src/utils/stories/index.jsx
@@ -1,9 +1,9 @@
 import React, { Fragment } from "react";
 import CustomDocsPage from "./CustomDocsPage";
 
-export const getDocsPageStructure = (name, blocks) => ({
+export const getDocsPageStructure = (name, intlSupport = true, notes = null) => ({
   docs: {
-    page: () => <CustomDocsPage blocks={blocks} name={name} />,
+    page: () => <CustomDocsPage intlSupport={intlSupport} name={name} notes={notes} />,
   },
 });
 

--- a/src/utils/stories/index.jsx
+++ b/src/utils/stories/index.jsx
@@ -1,65 +1,11 @@
 import React, { Fragment } from "react";
-import { Description, Primary, Props, Stories, Subtitle, Title } from "@storybook/addon-docs/blocks";
+import CustomDocsPage from "./CustomDocsPage";
 
-export const DOCS_PAGE_STRUCTURE = {
+export const getDocsPageStructure = (name, blocks) => ({
   docs: {
-    page: () => (
-      <Fragment>
-        <style
-          dangerouslySetInnerHTML={{
-            __html: `
-              .fake-sbdocs-title {
-                color: #333333 !important;
-                font-family: Arial !important;
-                cursor: text;
-                margin: 20px 0 8px;
-                padding: 0;
-                position: relative;
-              }
-              h2.fake-sbdocs-title {
-                border-bottom: 1px solid rgba(0,0,0,.1);
-                font-size: 24px;
-                padding-bottom: 4px;
-              }
-              h3.fake-sbdocs-title {
-                font-size: 20px;
-              }
-              .icon-wrapper {
-                align-items: center;
-                display: flex;
-              }
-              .icon-wrapper > span {
-                color: #333333 !important;
-                font-family: Arial !important;
-                font-size: 12px;
-                margin-left: 4px;
-              }
-              .stories-wrapper {
-                display: flex;
-                flex-wrap: wrap;
-              }
-              .stories-wrapper > * {
-                margin: 8px;
-              }
-              .typography-wrapper {
-                display: flex;
-                flex-direction: column;
-                width: 100%;
-              }
-            `,
-          }}
-        />
-        <Title />
-        <Subtitle />
-        <Description />
-        <Primary />
-        <Stories />
-        <h2 className="fake-sbdocs-title">Props</h2>
-        <Props />
-      </Fragment>
-    ),
+    page: () => <CustomDocsPage blocks={blocks} name={name} />,
   },
-};
+});
 
 export const StoriesWrapper = (props) => (
   <Fragment>

--- a/src/utils/stories/utils.tsx
+++ b/src/utils/stories/utils.tsx
@@ -10,8 +10,14 @@ You forgot to pass component name in your story page.
 Please fix the error adding the component name as first parameter for "getDocsPageStructure()" method in your story file.
 `;
 
+export const DEFAULT_BLOCKS_KEYS = {
+  CANVAS: "canvas",
+  INTL: "intl",
+  USAGE: "usage",
+};
+
 export const DEFAULT_BLOCKS = (component: string) => ({
-  usage: {
+  [DEFAULT_BLOCKS_KEYS.USAGE]: {
     title: "Usage",
     subtitle: true,
     body: (
@@ -27,7 +33,7 @@ export const DEFAULT_BLOCKS = (component: string) => ({
       </Fragment>
     ),
   },
-  intl: {
+  [DEFAULT_BLOCKS_KEYS.INTL]: {
     title: "Support for react-intl",
     subtitle: true,
     body: (
@@ -48,7 +54,7 @@ export const DEFAULT_BLOCKS = (component: string) => ({
       </Fragment>
     ),
   },
-  canvas: {
+  [DEFAULT_BLOCKS_KEYS.CANVAS]: {
     title: "Canvas",
     subtitle: true,
     body: (

--- a/src/utils/stories/utils.tsx
+++ b/src/utils/stories/utils.tsx
@@ -21,8 +21,8 @@ export const DEFAULT_BLOCKS = (component: string) => ({
         </p>
         <code className={CUSTOM_CODE_BLOCK_CLASS}>{`import { ${component} } from "melfore/mosaic";`}</code>
         <p>
-          For detailed usage and props settings refer to the <strong>Stories</strong> and <strong>Props</strong>{" "}
-          sections of this page
+          For detailed usage and props settings please refer to the <strong>Canvas</strong>, <strong>Stories</strong> or{" "}
+          <strong>Props</strong> sections of this page.
         </p>
       </Fragment>
     ),
@@ -43,7 +43,7 @@ export const DEFAULT_BLOCKS = (component: string) => ({
           Instead of passing <code>label</code> prop, provide <code>labelId</code> prop with the key-string to translate
           and it will automatically translate it.
           <br />
-          For more details refer to the example shown in the <strong>Stories/With Intl</strong> story.
+          For more details please refer to the example shown in the <strong>Stories/With Intl</strong> story.
         </p>
       </Fragment>
     ),
@@ -54,9 +54,13 @@ export const DEFAULT_BLOCKS = (component: string) => ({
     body: (
       <Fragment>
         <p>
-          The following story lists all available props for the component using <code>@storybook/addon-knobs</code>.
-          <br />
-          Click on the <strong>Show Code</strong> button to discover them all.
+          The following story shows a working example (sometimes mocking external functionalities) and lists all
+          available props for the component using <code>@storybook/addon-knobs</code>. Click on the{" "}
+          <strong>Show Code</strong> button to discover them all.
+        </p>
+        <p>
+          For specific usages and props combinations, please refer to the <strong>Stories</strong> and{" "}
+          <strong>Props</strong> sections of this page.
         </p>
       </Fragment>
     ),

--- a/src/utils/stories/utils.tsx
+++ b/src/utils/stories/utils.tsx
@@ -1,0 +1,128 @@
+import React, { Fragment } from "react";
+
+export const INVALID_COMPONENT_BLOCKS_ERROR = `
+You are passing component blocks in your story page.
+Please fix the error at "getDocsPageStructure()" method in your story file.
+`;
+
+export const MISSING_COMPONENT_NAME_ERROR = `
+You forgot to pass component name in your story page.
+Please fix the error adding the component name as first parameter for "getDocsPageStructure()" method in your story file.
+`;
+
+export const DEFAULT_BLOCKS = (component: string) => ({
+  usage: {
+    title: "Usage",
+    subtitle: true,
+    body: (
+      <Fragment>
+        <p>
+          Import <code>{component}</code> component adding this line to your code:
+        </p>
+        <code className={CUSTOM_CODE_BLOCK_CLASS}>{`import { ${component} } from "melfore/mosaic";`}</code>
+        <p>
+          For detailed usage and props settings refer to the <strong>Stories</strong> and <strong>Props</strong>{" "}
+          sections of this page
+        </p>
+      </Fragment>
+    ),
+  },
+  intl: {
+    title: "Support for react-intl",
+    subtitle: true,
+    body: (
+      <Fragment>
+        <p>
+          Supports usage inside <code>IntlProvider</code> context of <code>react-intl</code> using{" "}
+          <code>TypographyIntl</code> exported version.
+          <br />
+          You can import it adding this line to your code:
+        </p>
+        <code className={CUSTOM_CODE_BLOCK_CLASS}>{`import { ${component}Intl } from "melfore/mosaic";`}</code>
+        <p>
+          Instead of passing <code>label</code> prop, provide <code>labelId</code> prop with the key-string to translate
+          and it will automatically translate it.
+          <br />
+          For more details refer to the example shown in the <strong>Stories/With Intl</strong> story.
+        </p>
+      </Fragment>
+    ),
+  },
+  canvas: {
+    title: "Canvas",
+    subtitle: true,
+    body: (
+      <Fragment>
+        <p>
+          The following story lists all available props for the component using <code>@storybook/addon-knobs</code>.
+          <br />
+          Click on the <strong>Show Code</strong> button to discover them all.
+        </p>
+      </Fragment>
+    ),
+  },
+});
+
+export const CUSTOM_BODY_CLASS = "custom-sbdocs-body";
+export const CUSTOM_CODE_BLOCK_CLASS = "custom-code-block";
+export const CUSTOM_TITLES_CLASS = "custom-sbdocs-title";
+
+export const DOCS_PAGE_STYLE: string = `
+  .${CUSTOM_BODY_CLASS},
+  .${CUSTOM_TITLES_CLASS} {
+    color: #333333 !important;
+    font-family: Arial !important;
+    cursor: text;
+  }
+  .${CUSTOM_BODY_CLASS} {
+    font-size: 14px;
+    line-height: 24px;
+  }
+  .${CUSTOM_TITLES_CLASS} {
+    margin: 20px 0 8px;
+    padding: 0;
+    position: relative;
+  }
+  h2.${CUSTOM_TITLES_CLASS} {
+    border-bottom: 1px solid rgba(0,0,0,.1);
+    font-size: 24px;
+    padding-bottom: 4px;
+  }
+  h3.${CUSTOM_TITLES_CLASS} {
+    font-size: 20px;
+  }
+  .${CUSTOM_BODY_CLASS} code {
+    background-color: #F8F8F8;
+    font-family: "Operator Mono","Fira Code Retina","Fira Code","FiraCode-Retina","Andale Mono","Lucida Console",Consolas,Monaco,monospace;
+    font-size: 13px;
+    padding: 4px;
+  }
+  .${CUSTOM_BODY_CLASS} code.${CUSTOM_CODE_BLOCK_CLASS} {
+    background-color: #262626;
+    color: #EDEDED;
+    display: flex;
+    padding: 8px;
+  }
+  .icon-wrapper {
+    align-items: center;
+    display: flex;
+  }
+  .icon-wrapper > span {
+    color: #333333 !important;
+    font-family: Arial !important;
+    font-size: 12px;
+    margin-left: 4px;
+  }
+  .stories-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .stories-wrapper > * {
+    margin: 8px;
+  }
+  .typography-wrapper {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+`;


### PR DESCRIPTION
This fixes #76 .

Instead of the boilerplate code of the snipped I've decided to create a set of predefined doc blocks to auto generate desired documentation parts.

@masmau: **I've updated snippets to reflect these changes, follow guides inside CONTRIBUTING to update yours so you are aligned**

This is the final output:

<img width="815" alt="Screen Shot 2020-04-21 at 10 09 31" src="https://user-images.githubusercontent.com/61870694/79841903-5b777d00-83b8-11ea-821d-b1fb79e70651.png">

<hr>

**Detailed changes explained**

This is the new signature for `getDocsPageStructure` which expects the `name` of the component, a boolean flag `intlSupport` that by default it is true and the `notes` which are null.

```
export const getDocsPageStructure = (name, intlSupport = true, notes = null) => ({
  docs: {
    page: () => <CustomDocsPage intlSupport={intlSupport} name={name} notes={notes} />,
  },
});
```

`CustomDocsPage` is a JSX component (Storybook has no type defs for TypeScript support) which prints a set of HTML blocks with documentation.

This is a standard usage example, `Button` component (I need basic info and Intl):
```
export default {
  title: "Button",
  component: Button,
  parameters: {
    ...getDocsPageStructure("Button"),
  },
};
```

This is a custom usage example, `Switch` component (I need only basic info and not intl):
```
export default {
  title: "Switch",
  component: Switch,
  parameters: {
    ...getDocsPageStructure("Switch", false),
  },
};
```

This is an advanced usage example, `Typography` component (I need basic info, Intl and additional notes):
```
export default {
  title: "Typography",
  component: Typography,
  parameters: {
    ...getDocsPageStructure("Typography", true, {
      title: "Testing with cypress",
      subtitle: true,
      body: (
        <Fragment>
          <p>
            The implementation offered by <code>@material-ui</code> doesn't support dataCy attribute. The value of the
            <code>dataCy</code> property is being used by <code>className</code> with the <code>data-cy-</code> prefix.
          </p>
          <p>
            Example: passing <code>dataCy="typography"</code> results in <code>className="data-cy-typography"</code>.
          </p>
        </Fragment>
      ),
    }),
  },
};
```
