### PR TITLE
Add row selection in Table

### DIFF
--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -18,14 +18,13 @@ export default {
         <Fragment>
           <p>
             The <code>Table</code> component requires implementing callbacks for each event fired when interacting with
-            table features.
+            table features. Below you can find the properties responsible to handle table events:
           </p>
           <p>
-            <b>Pagination</b>
+            <b>Pagination:</b>
             <br />
             <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Properties
-                page: number (default is 0)
+              {`page: number (default is 0)
                 pageSize: number (default is 10)
                 onPageChange={(page: number) => {}}
                 onPageSizeChange={(pageSize: number) => {}}
@@ -33,30 +32,25 @@ export default {
             </code>
           </p>
           <p>
-            <b>Row click</b>
+            <b>Row click:</b>
             <br />
-            <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Properties
-                onRowClick={(event: any, row: any) => {}}
-              `}
-            </code>
+            <code className={CUSTOM_CODE_BLOCK_CLASS}>{`onRowClick={(event: any, row: any) => {}}`}</code>
           </p>
           <p>
-            <b>Search</b>
+            <b>Search:</b>
             <br />
-            <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Properties
-                onSearchChange={(query: string) => {}}
-              `}
-            </code>
+            <code className={CUSTOM_CODE_BLOCK_CLASS}>{`onSearchChange={(query: string) => {}}`}</code>
           </p>
           <p>
-            <b>Sorting</b>
+            <b>Selection:</b>
+            <br />
+            <code className={CUSTOM_CODE_BLOCK_CLASS}>{`onSelectionChange={(data: any[]) => {}}`}</code>
+          </p>
+          <p>
+            <b>Sorting:</b>
             <br />
             <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Properties
-                onSortChange={(path: string | null, criteria: "asc" | "desc") => {}}
-              `}
+              {`onSortChange={(path: string | null, criteria: "asc" | "desc") => {}}`}
             </code>
           </p>
         </Fragment>
@@ -76,6 +70,7 @@ export const Canvas = () => (
     onPageSizeChange={action("On Page Size Change")}
     onRowClick={action("On Row Click")}
     onSearchChange={action("On Search Change")}
+    onSelectionChange={action("On Selection Change")}
     onSortChange={action("On Sort Change")}
     page={number("page", 0)}
     pageSize={number("pageSize", 10)}

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -86,25 +86,57 @@ export const Canvas = () => (
   />
 );
 
-export const WithCustomRendering = () => (
+export const Basic = () => (
+  <Table
+    columns={[
+      { label: "Name", path: "name" },
+      { label: "Age", path: "age" },
+    ]}
+    rows={[
+      { name: "John", age: 35 },
+      { name: "Nick", age: 45 },
+      { name: "Emma", age: 32 },
+      { name: "Joey", age: 29 },
+      { name: "Luis", age: 78 },
+    ]}
+    title="Basic"
+  />
+);
+
+export const Loading = () => (
+  <Table
+    columns={[
+      { label: "Name", path: "name" },
+      { label: "Age", path: "age" },
+    ]}
+    loading
+    rows={[
+      { name: "John", age: 35 },
+      { name: "Nick", age: 45 },
+      { name: "Emma", age: 32 },
+      { name: "Joey", age: 29 },
+      { name: "Luis", age: 78 },
+    ]}
+    title="Without Events"
+  />
+);
+
+export const WithCustomColumnRender = () => (
   <StoriesWrapper>
     <Table
-      actions={[
-        {
-          callback: action("On Add Callback"),
-          icon: Icons.add,
-          label: "Add",
-        },
-      ]}
       columns={[
-        { label: "Name", path: "name", render: ({ name }) => <b>{name}</b> },
+        {
+          label: "Name",
+          path: "name",
+          render: ({ name }) => (
+            <div style={{ alignItems: "center", display: "flex" }}>
+              <img src={`https://eu.ui-avatars.com/api/?name=${name}&rounded=true&size=24`} />
+              <b style={{ marginLeft: "8px" }}>{name}</b>
+            </div>
+          ),
+        },
         { label: "Age", path: "age" },
       ]}
-      onPageChange={(page: number) => {}}
-      onPageSizeChange={(pageSize: number) => {}}
-      onRowClick={(event: any, row: any) => {}}
-      onSearchChange={(query: string) => {}}
-      onSortChange={(path: string | null, criteria: "asc" | "desc") => {}}
       rows={[
         { name: "John", age: 35 },
         { name: "Nick", age: 45 },
@@ -112,13 +144,35 @@ export const WithCustomRendering = () => (
         { name: "Joey", age: 29 },
         { name: "Luis", age: 78 },
       ]}
-      rowsTotal={5}
       title="Custom Rendering"
     />
   </StoriesWrapper>
 );
 
-export const WithGlobalActions = () => (
+export const WithEvents = () => (
+  <Table
+    columns={[
+      { label: "Name", path: "name" },
+      { label: "Age", path: "age" },
+    ]}
+    onPageChange={(page: number) => {}}
+    onPageSizeChange={(pageSize: number) => {}}
+    onRowClick={(row: any) => {}}
+    onSearchChange={(query: string) => {}}
+    onSelectionChange={(data: any[]) => {}}
+    onSortChange={(path: string | null, criteria: "asc" | "desc") => {}}
+    rows={[
+      { name: "John", age: 35 },
+      { name: "Nick", age: 45 },
+      { name: "Emma", age: 32 },
+      { name: "Joey", age: 29 },
+      { name: "Luis", age: 78 },
+    ]}
+    title="Without Events"
+  />
+);
+
+export const WithGlobalAction = () => (
   <StoriesWrapper>
     <Table
       actions={[
@@ -132,11 +186,6 @@ export const WithGlobalActions = () => (
         { label: "Name", path: "name" },
         { label: "Age", path: "age" },
       ]}
-      onPageChange={(page: number) => {}}
-      onPageSizeChange={(pageSize: number) => {}}
-      onRowClick={(event: any, row: any) => {}}
-      onSearchChange={(query: string) => {}}
-      onSortChange={(path: string | null, criteria: "asc" | "desc") => {}}
       rows={[
         { name: "John", age: 35 },
         { name: "Nick", age: 45 },
@@ -144,8 +193,7 @@ export const WithGlobalActions = () => (
         { name: "Joey", age: 29 },
         { name: "Luis", age: 78 },
       ]}
-      rowsTotal={5}
-      title="Global Actions"
+      title="Global Action"
     />
   </StoriesWrapper>
 );
@@ -162,6 +210,7 @@ export const WithRowActions = () => (
         },
         {
           callback: action("On Delete Callback"),
+          disabled: true,
           icon: Icons.delete,
           label: "Delete",
           scope: TableActionScope.row,
@@ -171,11 +220,6 @@ export const WithRowActions = () => (
         { label: "Name", path: "name" },
         { label: "Age", path: "age" },
       ]}
-      onPageChange={(page: number) => {}}
-      onPageSizeChange={(pageSize: number) => {}}
-      onRowClick={(event: any, row: any) => {}}
-      onSearchChange={(query: string) => {}}
-      onSortChange={(path: string | null, criteria: "asc" | "desc") => {}}
       rows={[
         { name: "John", age: 35 },
         { name: "Nick", age: 45 },
@@ -183,7 +227,6 @@ export const WithRowActions = () => (
         { name: "Joey", age: 29 },
         { name: "Luis", age: 78 },
       ]}
-      rowsTotal={5}
       title="Row Actions"
     />
   </StoriesWrapper>

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -71,7 +71,6 @@ export const Canvas = () => (
       { label: "Name", path: "name" },
       { label: "Age", path: "age" },
     ]}
-    filterable={boolean("filterable", false)}
     loading={boolean("loading", false)}
     onPageChange={action("On Page Change")}
     onPageSizeChange={action("On Page Size Change")}

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -17,19 +17,16 @@ export default {
       body: (
         <Fragment>
           <p>
-            The <code>Table</code> component requires utilizing project to handle events fired when interacting with the
+            The <code>Table</code> component requires implementing callbacks for each event fired when interacting with
             table features.
           </p>
           <p>
             <b>Pagination</b>
             <br />
             <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Props
+              {`// Properties
                 page: number (default is 0)
                 pageSize: number (default is 10)
-                paginated: boolean (default is true)
-
-                // Events (must be implemented to make pagination work)
                 onPageChange={(page: number) => {}}
                 onPageSizeChange={(pageSize: number) => {}}
               `}
@@ -39,7 +36,7 @@ export default {
             <b>Row click</b>
             <br />
             <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Event (must be implemented to make row click work)
+              {`// Properties
                 onRowClick={(event: any, row: any) => {}}
               `}
             </code>
@@ -48,10 +45,7 @@ export default {
             <b>Search</b>
             <br />
             <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Props
-                searchable: boolean (default is true)
-
-                // Event (must be implemented to make search work)
+              {`// Properties
                 onSearchChange={(query: string) => {}}
               `}
             </code>
@@ -60,10 +54,7 @@ export default {
             <b>Sorting</b>
             <br />
             <code className={CUSTOM_CODE_BLOCK_CLASS}>
-              {`// Props
-                sortable: boolean (default is true)
-
-                // Event (must be implemented to make sorting work)
+              {`// Properties
                 onSortChange={(path: string | null, criteria: "asc" | "desc") => {}}
               `}
             </code>
@@ -89,7 +80,6 @@ export const Canvas = () => (
     onSortChange={action("On Sort Change")}
     page={number("page", 0)}
     pageSize={number("pageSize", 10)}
-    paginated={boolean("paginated", true)}
     rows={[
       { name: "John", age: 35 },
       { name: "Nick", age: 45 },
@@ -98,8 +88,6 @@ export const Canvas = () => (
       { name: "Luis", age: 78 },
     ]}
     rowsTotal={number("rowsTotal", 5)}
-    searchable={boolean("searchable", true)}
-    sortable={boolean("sortable", true)}
     title={text("title", "Table Title")}
   />
 );

--- a/src/components/Table/index.test.tsx
+++ b/src/components/Table/index.test.tsx
@@ -2,17 +2,13 @@ import React from "react";
 import { mount } from "enzyme";
 import Table from ".";
 import { Icons } from "../../types/Icon";
+import { TableActionScope } from "../../types/Table";
 
 const defaultProps = {
   columns: [
     { label: "Name", path: "name" },
     { label: "Age", path: "age" },
   ],
-  onPageChange: jest.fn(),
-  onPageSizeChange: jest.fn(),
-  onRowClick: jest.fn(),
-  onSearchChange: jest.fn(),
-  onSortChange: jest.fn(),
   rows: [
     { name: "John", age: 35 },
     { name: "Nick", age: 45 },
@@ -27,23 +23,19 @@ const componentWrapper = (props = {}) => <Table {...defaultProps} {...props} />;
 
 describe("Table test suite:", () => {
   it("default", () => {
-    const sortCallback = jest.fn();
-    const component = componentWrapper({ onSortChange: sortCallback });
+    const component = componentWrapper();
     const wrapper = mount(component);
     const tableTitle = wrapper.find("h6");
     expect(tableTitle.text()).toEqual(defaultProps.title);
     const tableHead = wrapper.find("thead");
     const tableHeadCells = tableHead.find("th");
     expect(tableHeadCells).toHaveLength(defaultProps.columns.length);
-    const firstTableHeadCell = tableHeadCells.first().find("span.MuiTableSortLabel-root");
-    firstTableHeadCell.simulate("click");
-    expect(sortCallback).toHaveBeenCalledTimes(1);
     const tableBody = wrapper.find("tbody");
     const tableBodyRows = tableBody.find("tr");
     expect(tableBodyRows).toHaveLength(defaultProps.rows.length);
   });
 
-  it("with actions", () => {
+  it("with action global", () => {
     const actionCallback = jest.fn();
     const component = componentWrapper({
       actions: [
@@ -51,18 +43,6 @@ describe("Table test suite:", () => {
           callback: actionCallback,
           icon: Icons.add,
           label: "Add",
-        },
-        {
-          callback: actionCallback,
-          disabled: true,
-          icon: Icons.add,
-          label: "Refresh",
-        },
-        {
-          callback: actionCallback,
-          hidden: true,
-          icon: Icons.add,
-          label: "Export",
         },
       ],
     });
@@ -73,17 +53,59 @@ describe("Table test suite:", () => {
     expect(actionCallback).toHaveBeenCalledTimes(1);
   });
 
-  it("without interaction events", () => {
+  it("with action row", () => {
+    const actionCallback = jest.fn();
     const component = componentWrapper({
-      paginated: false,
-      searchable: false,
-      sortable: false,
+      actions: [
+        {
+          callback: actionCallback,
+          icon: Icons.delete,
+          label: "Delete",
+          scope: TableActionScope.row,
+        },
+      ],
     });
     const wrapper = mount(component);
-    const tableHead = wrapper.find("thead");
-    const tableHeadCells = tableHead.find("th");
-    expect(tableHeadCells).toHaveLength(defaultProps.columns.length);
-    const firstTableHeadCell = tableHeadCells.first().find("span.MuiTableSortLabel-root");
-    expect(firstTableHeadCell).toEqual({});
+  });
+
+  it("with loading", () => {
+    const component = componentWrapper({ loading: false });
+    const wrapper = mount(component);
+  });
+
+  it("with pagination", () => {
+    const pageChangeCallback = jest.fn();
+    const pageSizeChangeCallback = jest.fn();
+    const component = componentWrapper({
+      onPageChange: pageChangeCallback,
+      onPageSizeChange: pageSizeChangeCallback,
+      pageSize: 5,
+      rows: [...defaultProps.rows, { name: "Tina", age: 44 }],
+    });
+    const wrapper = mount(component);
+  });
+
+  it("with row click", () => {
+    const rowClickCallback = jest.fn();
+    const component = componentWrapper({ onRowClick: rowClickCallback });
+    const wrapper = mount(component);
+  });
+
+  it("with search", () => {
+    const searchChangeCallback = jest.fn();
+    const component = componentWrapper({ onSearchChange: searchChangeCallback });
+    const wrapper = mount(component);
+  });
+
+  it("with selection", () => {
+    const selectionChangeCallback = jest.fn();
+    const component = componentWrapper({ onSelectionChange: selectionChangeCallback });
+    const wrapper = mount(component);
+  });
+
+  it("with sorting", () => {
+    const sortChangeCallback = jest.fn();
+    const component = componentWrapper({ onSortChange: sortChangeCallback });
+    const wrapper = mount(component);
   });
 });

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -16,6 +16,7 @@ const Table: FC<TableType> = ({
   onPageSizeChange = undefined,
   onRowClick = undefined,
   onSearchChange = undefined,
+  onSelectionChange = undefined,
   onSortChange,
   page = 0,
   pageSize = 10,
@@ -72,6 +73,11 @@ const Table: FC<TableType> = ({
             onSearchChange(query);
           }
         }}
+        onSelectionChange={(data) => {
+          if (onSelectionChange) {
+            onSelectionChange(data);
+          }
+        }}
         options={{
           ...DEFAULT_TABLE_OPTIONS,
           filtering: filterable,
@@ -81,6 +87,7 @@ const Table: FC<TableType> = ({
           paging: paginated,
           search: searchable,
           sorting: sortable,
+          selection: !!onSelectionChange,
         }}
         page={page}
         title={title}

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -17,14 +17,11 @@ const Table: FC<TableType> = ({
   onRowClick = undefined,
   onSearchChange = undefined,
   onSelectionChange = undefined,
-  onSortChange,
+  onSortChange = undefined,
   page = 0,
   pageSize = 10,
-  paginated = true,
   rows = [],
   rowsTotal = undefined,
-  searchable = true,
-  sortable = true,
   title = undefined,
 }) => {
   return (
@@ -47,18 +44,18 @@ const Table: FC<TableType> = ({
           SortArrow: iconAdapter(Icons.arrowUp, IconSize.small),
         }}
         isLoading={loading}
-        onChangePage={(page: number) => {
-          if (paginated && onPageChange) {
+        onChangePage={(page) => {
+          if (onPageChange) {
             onPageChange(page);
           }
         }}
-        onChangeRowsPerPage={(pageSize: number) => {
-          if (paginated && onPageSizeChange) {
+        onChangeRowsPerPage={(pageSize) => {
+          if (onPageSizeChange) {
             onPageSizeChange(pageSize);
           }
         }}
-        onOrderChange={(columnIndex: number, criteria: "asc" | "desc") => {
-          if (sortable && onSortChange) {
+        onOrderChange={(columnIndex, criteria) => {
+          if (onSortChange) {
             const columnPath = columnIndex < 0 ? null : columns[columnIndex].path;
             onSortChange(columnPath, criteria);
           }
@@ -68,8 +65,8 @@ const Table: FC<TableType> = ({
             onRowClick(event, row);
           }
         }}
-        onSearchChange={(query: string) => {
-          if (searchable && onSearchChange) {
+        onSearchChange={(query) => {
+          if (onSearchChange) {
             onSearchChange(query);
           }
         }}
@@ -84,9 +81,9 @@ const Table: FC<TableType> = ({
           // TODO#lb: implement
           padding: "dense",
           pageSize,
-          paging: paginated,
-          search: searchable,
-          sorting: sortable,
+          paging: !!onPageChange && !!onPageSizeChange,
+          search: !!onSearchChange,
+          sorting: !!onSortChange,
           selection: !!onSelectionChange,
         }}
         page={page}

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -10,7 +10,6 @@ import { DEFAULT_TABLE_OPTIONS, actionAdapter, actionComponentAdapter, columnAda
 const Table: FC<TableType> = ({
   actions = [],
   columns,
-  filterable = false,
   loading = false,
   onPageChange = undefined,
   onPageSizeChange = undefined,
@@ -77,8 +76,7 @@ const Table: FC<TableType> = ({
         }}
         options={{
           ...DEFAULT_TABLE_OPTIONS,
-          filtering: filterable,
-          // TODO#lb: implement
+          filtering: false,
           padding: "dense",
           pageSize,
           paging: !!onPageChange && !!onPageSizeChange,

--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -45,6 +45,7 @@ export interface TableType extends BaseType {
   onPageSizeChange?: (pageSize: number) => void;
   onRowClick?: (event: any, row: any) => void;
   onSearchChange?: (query: string) => void;
+  onSelectionChange?: (data: any[]) => void;
   onSortChange: (path: string | null, criteria: "asc" | "desc") => void;
   page?: number;
   pageSize?: number;

--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -46,19 +46,14 @@ export interface TableType extends BaseType {
   onRowClick?: (event: any, row: any) => void;
   onSearchChange?: (query: string) => void;
   onSelectionChange?: (data: any[]) => void;
-  onSortChange: (path: string | null, criteria: "asc" | "desc") => void;
+  onSortChange?: (path: string | null, criteria: "asc" | "desc") => void;
   page?: number;
   pageSize?: number;
-  paginated?: boolean;
   // TODO#lb: implement
   // rowDimension?: TableRowDimension;
   rows: any[];
   // TODO#lb: implement
   // rowsFiltered?: number;
   rowsTotal?: number;
-  searchable?: boolean;
-  // TODO#lb implement
-  // selectable?: boolean;
-  sortable?: boolean;
   title: string;
 }

--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -2,13 +2,6 @@ import { ReactElement } from "react";
 import { BaseType } from "./Base";
 import { Icons } from "./Icon";
 
-// TODO#lb: implement
-// export enum TableRowDimension {
-//   large = "default",
-//   medium = "dense",
-//   small = "small",
-// }
-
 export enum TableActionScope {
   default = "global",
   row = "row",
@@ -24,11 +17,6 @@ export interface TableActionType {
 }
 
 export interface TableColumnType {
-  // TODO#lb: implement in TableColumn
-  // defaultFilter?: any;
-  // export?: false;
-  // filtering?: boolean;
-  // searchable?: boolean;
   label?: string;
   path: string;
   render?: (row: any) => ReactElement;
@@ -37,9 +25,6 @@ export interface TableColumnType {
 export interface TableType extends BaseType {
   actions?: TableActionType[];
   columns: TableColumnType[];
-  // TODO#lb: implement
-  // exportable?: boolean;
-  filterable?: boolean;
   loading?: boolean;
   onPageChange?: (page: number) => void;
   onPageSizeChange?: (pageSize: number) => void;
@@ -49,11 +34,7 @@ export interface TableType extends BaseType {
   onSortChange?: (path: string | null, criteria: "asc" | "desc") => void;
   page?: number;
   pageSize?: number;
-  // TODO#lb: implement
-  // rowDimension?: TableRowDimension;
   rows: any[];
-  // TODO#lb: implement
-  // rowsFiltered?: number;
   rowsTotal?: number;
   title: string;
 }


### PR DESCRIPTION
This PR adds row selection in Table component providing the `onSelectionChange` callback.

It also refactors the `TableType` removing the boolean flags to enable events. They were redundant since I can use as flag the check on the callbacks.

Improved `Table` docs and tests (only stubbed to guarantee coverage).