### PR TITLE
Make Card component loadable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2823,6 +2823,19 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.54",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.54.tgz",
+      "integrity": "sha512-BK/z+8xGPQoMtG6gWKyagCdYO1/2DzkBchvvXs2bbTVh3sbi/QQLIqWV6UA1KtMVydYVt22NwV3xltgPkaPKLg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/pickers": {
       "version": "3.2.10",
       "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.2.10.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/core": "^7.9.0",
     "@material-ui/core": "^4.9.5",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.54",
     "@storybook/addon-actions": "^5.3.17",
     "@storybook/addon-docs": "^5.3.17",
     "@storybook/addon-knobs": "^5.3.17",
@@ -54,6 +55,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.9.x",
     "@material-ui/icons": "4.9.x",
+    "@material-ui/lab": "4.0.0-alpha.54",
     "react": "16.13.x",
     "react-dom": "16.13.x",
     "react-intl": "4.3.x"

--- a/src/components/Avatar/index.stories.tsx
+++ b/src/components/Avatar/index.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { select, text } from "@storybook/addon-knobs";
+import { select, text, boolean } from "@storybook/addon-knobs";
 import { AvatarVariant } from "../../types/Avatar";
 import { Icons } from "../../types/Icon";
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
@@ -18,6 +18,7 @@ export const Canvas = () => (
     alt={text("alt", "Alt Text")}
     dataCy={text("dataCy", "avatar")}
     icon={select("icon", Icons, Icons.add)}
+    loading={boolean("loading", false)}
     text={text("text", "Avatar Text")}
     variant={select("variant", AvatarVariant, AvatarVariant.default)}
   />
@@ -26,6 +27,12 @@ export const Canvas = () => (
 export const Icon = () => (
   <StoriesWrapper>
     <Avatar icon={Icons.business} />
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <Avatar loading />
   </StoriesWrapper>
 );
 

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo } from "react";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
 import { AvatarType, AvatarVariant } from "../../types/Avatar";
 import Icon from "../Icon";
 import Typography from "../Typography";
@@ -11,10 +12,19 @@ const Avatar: FC<AvatarType> = ({
   alt = "avatar",
   dataCy = "avatar",
   icon = undefined,
+  loading = false,
   src = undefined,
   text = undefined,
   variant = AvatarVariant.default,
 }) => {
+  if (loading) {
+    return (
+      <MUISkeleton variant="circle">
+        <StyledMUIAvatar />
+      </MUISkeleton>
+    );
+  }
+
   return (
     <StyledMUIAvatar alt={text || alt} className={`data-cy-${dataCy}`} src={src || undefined} variant={variant}>
       {icon && <Icon name={icon} />}

--- a/src/components/Card/index.stories.tsx
+++ b/src/components/Card/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import { text, select } from "@storybook/addon-knobs";
+import { text, select, boolean } from "@storybook/addon-knobs";
 import { Icons } from "../../types/Icon";
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Button from "../Button";
@@ -29,6 +29,7 @@ export const Canvas = () => (
       <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together. Mosaic are used as decoration. Architects use mosaic murals for kitchen backsplash, shower wall and entry floor art. Mosaic Craft items are used as home decor. Cities often decorate public places such as parks with mosaic murals and sculptures." />
     }
     icon={select("icon", Icons, Icons.add)}
+    loading={boolean("loading", false)}
     subtitle={text("subTitle", "Mosaic Card Subtitle")}
     title={text("title", "Mosaic Card")}
   />
@@ -40,6 +41,26 @@ export const Basic = () => (
       content={
         <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together." />
       }
+      title="Mosaic"
+    />
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <Card
+      content={
+        <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together." />
+      }
+      loading
+      title="Mosaic"
+    />
+    <Card
+      content={
+        <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together." />
+      }
+      icon={Icons.add}
+      loading
       title="Mosaic"
     />
   </StoriesWrapper>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,5 +1,6 @@
-import React, { cloneElement, FC, useState, useMemo } from "react";
-import { Collapse as MUICollapse } from "@material-ui/core";
+import React, { cloneElement, FC, Fragment, useState, useMemo } from "react";
+import { Collapse as MUICollapse, useTheme } from "@material-ui/core";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
 import { CardType } from "../../types/Card";
 import { Icons } from "../../types/Icon";
 import { TypographyVariants } from "../../types/Typography";
@@ -22,40 +23,66 @@ const Card: FC<CardType> = ({
   collapsible = undefined,
   content,
   icon = undefined,
+  loading = false,
   title,
   subtitle = undefined,
   unmountCollapsible = false,
 }) => {
   const [expanded, setExpanded] = useState(false);
+  const theme = useTheme();
 
   const cardHeader = useMemo(
     () => (
       <StyledMUICardHeader
-        avatar={icon && <Avatar icon={icon} />}
+        avatar={icon && <Avatar icon={icon} loading={loading} />}
         disableTypography
-        title={<Typography bottomSpacing={false} label={title} truncated variant={TypographyVariants.title} />}
-        subheader={<Typography label={subtitle} truncated variant={TypographyVariants.caption} />}
+        title={
+          <Typography
+            bottomSpacing={false}
+            label={title}
+            loading={loading}
+            truncated
+            variant={TypographyVariants.title}
+          />
+        }
+        subheader={
+          <Typography
+            bottomSpacing={false}
+            label={subtitle}
+            loading={loading}
+            truncated
+            variant={TypographyVariants.caption}
+          />
+        }
       />
     ),
-    [icon, subtitle, title]
+    [icon, loading, subtitle, title]
   );
 
   return (
     <StyledMUICard>
       {cardHeader}
-      <StyledMUICardContent>{content}</StyledMUICardContent>
-      <StyledMUICardActions disableSpacing>
-        {actions.length > 0 && (
-          <ActionsWrapper alignItems="center" display="flex">
-            {actions.map((action, index) => cloneElement(action, { key: `card-action-${index}` }))}
-          </ActionsWrapper>
-        )}
-        {collapsible && <IconButton icon={expanded ? Icons.up : Icons.down} onClick={() => setExpanded(!expanded)} />}
-      </StyledMUICardActions>
-      {collapsible && (
-        <MUICollapse in={expanded} timeout="auto" unmountOnExit={unmountCollapsible}>
-          <StyledMUICardContent>{collapsible}</StyledMUICardContent>
-        </MUICollapse>
+      <StyledMUICardContent>
+        {loading ? <MUISkeleton height={`${theme.spacing(16)}px`} /> : content}
+      </StyledMUICardContent>
+      {!loading && (
+        <Fragment>
+          <StyledMUICardActions disableSpacing>
+            {actions.length > 0 && (
+              <ActionsWrapper alignItems="center" display="flex">
+                {actions.map((action, index) => cloneElement(action, { key: `card-action-${index}` }))}
+              </ActionsWrapper>
+            )}
+            {collapsible && (
+              <IconButton icon={expanded ? Icons.up : Icons.down} onClick={() => setExpanded(!expanded)} />
+            )}
+          </StyledMUICardActions>
+          {collapsible && (
+            <MUICollapse in={expanded} timeout="auto" unmountOnExit={unmountCollapsible}>
+              <StyledMUICardContent>{collapsible}</StyledMUICardContent>
+            </MUICollapse>
+          )}
+        </Fragment>
       )}
     </StyledMUICard>
   );

--- a/src/components/Typography/index.stories.tsx
+++ b/src/components/Typography/index.stories.tsx
@@ -32,6 +32,7 @@ export const Canvas = () => (
   <Typography
     bottomSpacing={boolean("bottomSpacing", false)}
     label={text("label", "Typography example")}
+    loading={boolean("loading", false)}
     truncated={boolean("truncated", false)}
     variant={select("variant", TypographyVariants, TypographyVariants.body)}
     display={select("display", TypographyDisplay, TypographyDisplay.default)}
@@ -86,6 +87,14 @@ export const Inline = () => (
       <Typography label="caption " variant={TypographyVariants.caption} display={TypographyDisplay.inline} />
       <Typography label="label " variant={TypographyVariants.label} display={TypographyDisplay.inline} />
       <Typography label="overline " variant={TypographyVariants.overline} display={TypographyDisplay.inline} />
+    </div>
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <div className="typography-wrapper">
+      <Typography loading />
     </div>
   </StoriesWrapper>
 );

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
-import MUITypography from "@material-ui/core/Typography";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
+import { Typography as MUITypography } from "@material-ui/core";
 import { BaseIntlType } from "../../types/Base";
 import { TypographyType, TypographyVariants, TypographyDisplay } from "../../types/Typography";
 import withIntl from "../../utils/hocs/withIntl";
@@ -12,6 +13,7 @@ const Typography: FC<TypographyType> = ({
   bottomSpacing = undefined,
   dataCy = "typography",
   label,
+  loading = false,
   truncated = undefined,
   variant = TypographyVariants.body,
   display = TypographyDisplay.default,
@@ -25,7 +27,7 @@ const Typography: FC<TypographyType> = ({
       variantMapping={VARIANT_COMPONENT_MAP}
       display={display}
     >
-      {label}
+      {loading ? <MUISkeleton /> : label}
     </MUITypography>
   );
 };

--- a/src/types/Avatar.ts
+++ b/src/types/Avatar.ts
@@ -1,4 +1,4 @@
-import { BaseType } from "./Base";
+import { LoadableType } from "./Base";
 import { Icons } from "./Icon";
 
 export enum AvatarVariant {
@@ -7,7 +7,7 @@ export enum AvatarVariant {
   squared = "square",
 }
 
-export interface AvatarType extends BaseType {
+export interface AvatarType extends LoadableType {
   alt?: string;
   icon?: Icons;
   src?: string;

--- a/src/types/Base.ts
+++ b/src/types/Base.ts
@@ -13,3 +13,7 @@ export interface BaseType {
 export interface BaseIntlType extends BaseType {
   labelId: string;
 }
+
+export interface LoadableType extends BaseType {
+  loading?: boolean;
+}

--- a/src/types/Card.ts
+++ b/src/types/Card.ts
@@ -1,8 +1,8 @@
-import { BaseType } from "./Base";
+import { LoadableType } from "./Base";
 import { Icons } from "./Icon";
 import { ReactElement } from "react";
 
-export interface CardType extends BaseType {
+export interface CardType extends LoadableType {
   actions?: ReactElement[];
   collapsible?: ReactElement;
   content: ReactElement;

--- a/src/types/Typography.ts
+++ b/src/types/Typography.ts
@@ -1,4 +1,4 @@
-import { BaseType } from "./Base";
+import { LoadableType } from "./Base";
 
 export enum TypographyVariants {
   body = "body1",
@@ -15,7 +15,7 @@ export enum TypographyDisplay {
   inline = "inline",
 }
 
-export interface TypographyType extends BaseType {
+export interface TypographyType extends LoadableType {
   bottomSpacing?: boolean;
   label?: string;
   truncated?: boolean;


### PR DESCRIPTION
This PR adds a new base type: `LoadableType`. It extends `BaseType` adding the `loading?: boolean` property.

It is meant to target all data-display components (so excluding theoretically input and user interaction components) that might have a loading status, anticipating the need on projects that will use `@melfore/mosaic` bundle of components.

Currently this new base type applies to:
**Avatar**
<img width="1031" alt="Screen Shot 2020-05-28 at 16 07 36" src="https://user-images.githubusercontent.com/61870694/83151917-78ad1300-a0fd-11ea-9653-fc4235e50b25.png">

**Card**
<img width="1033" alt="Screen Shot 2020-05-28 at 16 07 59" src="https://user-images.githubusercontent.com/61870694/83151947-819de480-a0fd-11ea-8943-a981ec63c367.png">


**Typography**
<img width="1028" alt="Screen Shot 2020-05-28 at 16 08 13" src="https://user-images.githubusercontent.com/61870694/83151958-8793c580-a0fd-11ea-9048-422d0c9be7f2.png">


According to emerging needs it can be extended to other components.
