### PR TITLE
Add ListItem components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2823,6 +2823,19 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.54",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.54.tgz",
+      "integrity": "sha512-BK/z+8xGPQoMtG6gWKyagCdYO1/2DzkBchvvXs2bbTVh3sbi/QQLIqWV6UA1KtMVydYVt22NwV3xltgPkaPKLg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/pickers": {
       "version": "3.2.10",
       "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.2.10.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@babel/core": "^7.9.0",
     "@material-ui/core": "^4.9.5",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.54",
     "@storybook/addon-actions": "^5.3.17",
     "@storybook/addon-docs": "^5.3.17",
     "@storybook/addon-knobs": "^5.3.17",
@@ -54,6 +55,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.9.x",
     "@material-ui/icons": "4.9.x",
+    "@material-ui/lab": "4.0.0-alpha.54",
     "react": "16.13.x",
     "react-dom": "16.13.x",
     "react-intl": "4.3.x"

--- a/src/components/Avatar/index.stories.tsx
+++ b/src/components/Avatar/index.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { select, text } from "@storybook/addon-knobs";
+import { select, text, boolean } from "@storybook/addon-knobs";
 import { AvatarVariant } from "../../types/Avatar";
 import { Icons } from "../../types/Icon";
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
@@ -18,6 +18,7 @@ export const Canvas = () => (
     alt={text("alt", "Alt Text")}
     dataCy={text("dataCy", "avatar")}
     icon={select("icon", Icons, Icons.add)}
+    loading={boolean("loading", false)}
     text={text("text", "Avatar Text")}
     variant={select("variant", AvatarVariant, AvatarVariant.default)}
   />
@@ -26,6 +27,12 @@ export const Canvas = () => (
 export const Icon = () => (
   <StoriesWrapper>
     <Avatar icon={Icons.business} />
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <Avatar loading />
   </StoriesWrapper>
 );
 

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC, memo } from "react";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
 import { AvatarType, AvatarVariant } from "../../types/Avatar";
 import Icon from "../Icon";
 import Typography from "../Typography";
@@ -11,10 +12,19 @@ const Avatar: FC<AvatarType> = ({
   alt = "avatar",
   dataCy = "avatar",
   icon = undefined,
+  loading = false,
   src = undefined,
   text = undefined,
   variant = AvatarVariant.default,
 }) => {
+  if (loading) {
+    return (
+      <MUISkeleton variant="circle">
+        <StyledMUIAvatar />
+      </MUISkeleton>
+    );
+  }
+
   return (
     <StyledMUIAvatar alt={text || alt} className={`data-cy-${dataCy}`} src={src || undefined} variant={variant}>
       {icon && <Icon name={icon} />}

--- a/src/components/Card/index.stories.tsx
+++ b/src/components/Card/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import { text, select } from "@storybook/addon-knobs";
+import { text, select, boolean } from "@storybook/addon-knobs";
 import { Icons } from "../../types/Icon";
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Button from "../Button";
@@ -29,6 +29,7 @@ export const Canvas = () => (
       <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together. Mosaic are used as decoration. Architects use mosaic murals for kitchen backsplash, shower wall and entry floor art. Mosaic Craft items are used as home decor. Cities often decorate public places such as parks with mosaic murals and sculptures." />
     }
     icon={select("icon", Icons, Icons.add)}
+    loading={boolean("loading", false)}
     subtitle={text("subTitle", "Mosaic Card Subtitle")}
     title={text("title", "Mosaic Card")}
   />
@@ -40,6 +41,26 @@ export const Basic = () => (
       content={
         <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together." />
       }
+      title="Mosaic"
+    />
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <Card
+      content={
+        <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together." />
+      }
+      loading
+      title="Mosaic"
+    />
+    <Card
+      content={
+        <Typography label="A mosaic is an artistic picture or design made out of any materials assembled together." />
+      }
+      icon={Icons.add}
+      loading
       title="Mosaic"
     />
   </StoriesWrapper>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,5 +1,6 @@
-import React, { cloneElement, FC, useState, useMemo } from "react";
-import { Collapse as MUICollapse } from "@material-ui/core";
+import React, { cloneElement, FC, Fragment, useState, useMemo } from "react";
+import { Collapse as MUICollapse, useTheme } from "@material-ui/core";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
 import { CardType } from "../../types/Card";
 import { Icons } from "../../types/Icon";
 import { TypographyVariants } from "../../types/Typography";
@@ -22,40 +23,66 @@ const Card: FC<CardType> = ({
   collapsible = undefined,
   content,
   icon = undefined,
+  loading = false,
   title,
   subtitle = undefined,
   unmountCollapsible = false,
 }) => {
   const [expanded, setExpanded] = useState(false);
+  const theme = useTheme();
 
   const cardHeader = useMemo(
     () => (
       <StyledMUICardHeader
-        avatar={icon && <Avatar icon={icon} />}
+        avatar={icon && <Avatar icon={icon} loading={loading} />}
         disableTypography
-        title={<Typography bottomSpacing={false} label={title} truncated variant={TypographyVariants.title} />}
-        subheader={<Typography label={subtitle} truncated variant={TypographyVariants.caption} />}
+        title={
+          <Typography
+            bottomSpacing={false}
+            label={title}
+            loading={loading}
+            truncated
+            variant={TypographyVariants.title}
+          />
+        }
+        subheader={
+          <Typography
+            bottomSpacing={false}
+            label={subtitle}
+            loading={loading}
+            truncated
+            variant={TypographyVariants.caption}
+          />
+        }
       />
     ),
-    [icon, subtitle, title]
+    [icon, loading, subtitle, title]
   );
 
   return (
     <StyledMUICard>
       {cardHeader}
-      <StyledMUICardContent>{content}</StyledMUICardContent>
-      <StyledMUICardActions disableSpacing>
-        {actions.length > 0 && (
-          <ActionsWrapper alignItems="center" display="flex">
-            {actions.map((action, index) => cloneElement(action, { key: `card-action-${index}` }))}
-          </ActionsWrapper>
-        )}
-        {collapsible && <IconButton icon={expanded ? Icons.up : Icons.down} onClick={() => setExpanded(!expanded)} />}
-      </StyledMUICardActions>
-      {collapsible && (
-        <MUICollapse in={expanded} timeout="auto" unmountOnExit={unmountCollapsible}>
-          <StyledMUICardContent>{collapsible}</StyledMUICardContent>
-        </MUICollapse>
+      <StyledMUICardContent>
+        {loading ? <MUISkeleton height={`${theme.spacing(16)}px`} /> : content}
+      </StyledMUICardContent>
+      {!loading && (
+        <Fragment>
+          <StyledMUICardActions disableSpacing>
+            {actions.length > 0 && (
+              <ActionsWrapper alignItems="center" display="flex">
+                {actions.map((action, index) => cloneElement(action, { key: `card-action-${index}` }))}
+              </ActionsWrapper>
+            )}
+            {collapsible && (
+              <IconButton icon={expanded ? Icons.up : Icons.down} onClick={() => setExpanded(!expanded)} />
+            )}
+          </StyledMUICardActions>
+          {collapsible && (
+            <MUICollapse in={expanded} timeout="auto" unmountOnExit={unmountCollapsible}>
+              <StyledMUICardContent>{collapsible}</StyledMUICardContent>
+            </MUICollapse>
+          )}
+        </Fragment>
       )}
     </StyledMUICard>
   );

--- a/src/components/Icon/index.stories.tsx
+++ b/src/components/Icon/index.stories.tsx
@@ -17,6 +17,14 @@ export const Canvas = () => (
   <Icon dataCy="icon" name={select("icon", Icons, Icons.add)} size={select("size", IconSize, IconSize.default)} />
 );
 
+export const Loading = () => (
+  <StoriesWrapper>
+    <Icon dataCy="loading-icon" loading name={Icons.send} size={IconSize.small} />
+    <Icon dataCy="loading-icon" loading name={Icons.send} />
+    <Icon dataCy="loading-icon" loading name={Icons.send} size={IconSize.large} />
+  </StoriesWrapper>
+);
+
 export const Size = () => (
   <StoriesWrapper>
     <Icon dataCy="icon-send" name={Icons.send} size={IconSize.small} />

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,8 +1,25 @@
 import React, { FC } from "react";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
 import { IconType, IconSize } from "../../types/Icon";
 import { iconsCatalog } from "./utils";
 
-const Icon: FC<IconType> = ({ dataCy, forwarded = {}, name, size = IconSize.default }) => {
+const Icon: FC<IconType> = ({ dataCy, forwarded = {}, loading = false, name, size = IconSize.default }) => {
+  if (loading) {
+    const dimensions = ((size: IconSize): number => {
+      switch (size) {
+        case IconSize.small:
+          return 20;
+        default:
+        case IconSize.default:
+          return 24;
+        case IconSize.large:
+          return 35;
+      }
+    })(size);
+
+    return <MUISkeleton height={dimensions} variant="rect" width={dimensions} />;
+  }
+
   const icon = iconsCatalog[name];
   return React.cloneElement(icon, { ...forwarded, "data-cy": dataCy, fontSize: size });
 };

--- a/src/components/ListCollapsibleItem/index.stories.tsx
+++ b/src/components/ListCollapsibleItem/index.stories.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import { text, boolean, select } from "@storybook/addon-knobs";
+import { TypographyVariants } from "../../types/Typography";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
+import ListCollapsibleItem from ".";
+import Typography from "../Typography";
+
+export default {
+  title: "ListCollapsibleItem",
+  component: ListCollapsibleItem,
+  parameters: {
+    ...getDocsPageStructure("ListCollapsibleItem", false),
+  },
+};
+
+export const Canvas = () => (
+  <ListCollapsibleItem
+    children={<span>Collapsible Content</span>}
+    dataCy="list-item"
+    dense={boolean("dense", false)}
+    loading={boolean("loading", false)}
+    onClick={action("On ListItem click")}
+    open={boolean("open", false)}
+    openTimeout={select("openTimeout", ["auto", 1000, 5000], "auto")}
+    selected={boolean("selected", false)}
+    title={text("title", "ListItem Title")}
+    titleVariant={select("titleVariant", TypographyVariants, undefined)}
+    unmountContent={boolean("unmountContent", false)}
+  />
+);
+
+export const Basic = () => (
+  <StoriesWrapper>
+    <ListCollapsibleItem title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const Dense = () => (
+  <StoriesWrapper>
+    <ListCollapsibleItem title="Basic List Item" />
+    <ListCollapsibleItem dense title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <ListCollapsibleItem loading title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const Selected = () => (
+  <StoriesWrapper>
+    <ListCollapsibleItem selected title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const Open = () => (
+  <StoriesWrapper>
+    <ListCollapsibleItem open selected title="Basic List Item">
+      <div style={{ border: "1px solid #ccc", padding: "16px" }}>
+        <Typography label="Collapsible content is now expanded" />
+      </div>
+    </ListCollapsibleItem>
+  </StoriesWrapper>
+);
+
+export const WithTitleVariant = () => (
+  <StoriesWrapper>
+    <ListCollapsibleItem title="Basic List Item" titleVariant={TypographyVariants.caption} />
+  </StoriesWrapper>
+);

--- a/src/components/ListCollapsibleItem/index.test.tsx
+++ b/src/components/ListCollapsibleItem/index.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { mount } from "enzyme";
+import ListCollapsibleItem from ".";
+
+const defaultProps = {
+  title: "ListCollapsibleItem Title",
+};
+
+const componentWrapper = (props = {}) => <ListCollapsibleItem {...defaultProps} {...props} />;
+
+describe("ListCollapsibleItem test suite:", () => {
+  it("default", () => {
+    const component = componentWrapper();
+    const wrapper = mount(component);
+    const listItemTitle = wrapper.find("div.MuiListItemText-root");
+    const title = listItemTitle.find("p");
+    expect(title.text()).toEqual(defaultProps.title);
+  });
+});

--- a/src/components/ListCollapsibleItem/index.tsx
+++ b/src/components/ListCollapsibleItem/index.tsx
@@ -1,0 +1,38 @@
+import React, { FC, Fragment } from "react";
+import { Collapse as MUICollapse } from "@material-ui/core";
+import { ListCollapsibleItemType } from "../../types/ListItem";
+import ListItem from "../ListItem";
+import { Icons } from "../../types/Icon";
+import { TypographyVariants } from "../../types/Typography";
+
+const ListCollapsibleItem: FC<ListCollapsibleItemType> = ({
+  children,
+  dense = false,
+  loading = false,
+  onClick,
+  open = false,
+  openTimeout = "auto",
+  selected = false,
+  title,
+  titleVariant = TypographyVariants.body,
+  unmountContent = false,
+}) => {
+  return (
+    <Fragment>
+      <ListItem
+        dense={dense}
+        icon={open ? Icons.up : Icons.down}
+        loading={loading}
+        onClick={onClick}
+        selected={selected}
+        title={title}
+        titleVariant={titleVariant}
+      />
+      <MUICollapse in={open} timeout={openTimeout} unmountOnExit={unmountContent}>
+        {children}
+      </MUICollapse>
+    </Fragment>
+  );
+};
+
+export default ListCollapsibleItem;

--- a/src/components/ListItem/index.stories.tsx
+++ b/src/components/ListItem/index.stories.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import { text, boolean, select } from "@storybook/addon-knobs";
+import { Icons } from "../../types/Icon";
+import { TypographyVariants } from "../../types/Typography";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
+import ListItem from ".";
+
+export default {
+  title: "ListItem",
+  component: ListItem,
+  parameters: {
+    ...getDocsPageStructure("ListItem", false),
+  },
+};
+
+export const Canvas = () => (
+  <ListItem
+    dataCy="list-item"
+    dense={boolean("dense", false)}
+    icon={select("icon", Icons, undefined)}
+    loading={boolean("loading", false)}
+    onClick={action("On ListItem click")}
+    selected={boolean("selected", false)}
+    title={text("title", "ListItem Title")}
+    titleVariant={select("titleVariant", TypographyVariants, undefined)}
+  />
+);
+
+export const Basic = () => (
+  <StoriesWrapper>
+    <ListItem title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const Dense = () => (
+  <StoriesWrapper>
+    <ListItem title="Basic List Item" />
+    <ListItem dense title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <ListItem loading title="Basic List Item" />
+    <ListItem icon={Icons.add} loading title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const Selected = () => (
+  <StoriesWrapper>
+    <ListItem selected title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const WithIcon = () => (
+  <StoriesWrapper>
+    <ListItem icon={Icons.add} title="Basic List Item" />
+  </StoriesWrapper>
+);
+
+export const WithTitleVariant = () => (
+  <StoriesWrapper>
+    <ListItem icon={Icons.add} title="Basic List Item" titleVariant={TypographyVariants.caption} />
+  </StoriesWrapper>
+);

--- a/src/components/ListItem/index.test.tsx
+++ b/src/components/ListItem/index.test.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { mount } from "enzyme";
+import ListItem from ".";
+
+const defaultProps = {
+  title: "ListItem Title",
+};
+
+const componentWrapper = (props = {}) => <ListItem {...defaultProps} {...props} />;
+
+describe("ListItem test suite:", () => {
+  it("default", () => {
+    const component = componentWrapper();
+    const wrapper = mount(component);
+    const listItemTitle = wrapper.find("div.MuiListItemText-root");
+    const title = listItemTitle.find("p");
+    expect(title.text()).toEqual(defaultProps.title);
+  });
+});

--- a/src/components/ListItem/index.tsx
+++ b/src/components/ListItem/index.tsx
@@ -1,0 +1,64 @@
+import React, { FC, memo, ReactElement, useMemo } from "react";
+import {
+  ListItem as MUIListItem,
+  ListItemIcon as MUIListItemIcon,
+  ListItemText as MUIListItemText,
+} from "@material-ui/core";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
+import { ListItemType } from "../../types/ListItem";
+import { TypographyVariants } from "../../types/Typography";
+import Typography from "../Typography";
+import Icon from "../Icon";
+
+/**
+ * ListItem component made on top of `@material-ui/core/ListItem`
+ */
+const ListItem: FC<ListItemType> = ({
+  dense = true,
+  icon = undefined,
+  loading = false,
+  onClick = undefined,
+  selected = false,
+  title,
+  titleVariant = TypographyVariants.body,
+}) => {
+  const text = useMemo(
+    () =>
+      typeof title !== "string" ? (
+        loading ? (
+          <MUISkeleton />
+        ) : (
+          title
+        )
+      ) : (
+        <Typography bottomSpacing={false} label={title} loading={loading} truncated variant={titleVariant} />
+      ),
+    [loading, title, titleVariant]
+  );
+
+  return (
+    <MUIListItem
+      dense={dense}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (loading) {
+          return;
+        }
+
+        onClick && onClick();
+      }}
+      selected={!loading && selected}
+      style={{ cursor: !loading && onClick ? "pointer" : "default" }}
+    >
+      {icon && (
+        <MUIListItemIcon>
+          <Icon loading={loading} name={icon} />
+        </MUIListItemIcon>
+      )}
+      <MUIListItemText disableTypography>{text}</MUIListItemText>
+    </MUIListItem>
+  );
+};
+
+export default memo(ListItem);

--- a/src/components/Typography/index.stories.tsx
+++ b/src/components/Typography/index.stories.tsx
@@ -32,6 +32,7 @@ export const Canvas = () => (
   <Typography
     bottomSpacing={boolean("bottomSpacing", false)}
     label={text("label", "Typography example")}
+    loading={boolean("loading", false)}
     truncated={boolean("truncated", false)}
     variant={select("variant", TypographyVariants, TypographyVariants.body)}
     display={select("display", TypographyDisplay, TypographyDisplay.default)}
@@ -86,6 +87,14 @@ export const Inline = () => (
       <Typography label="caption " variant={TypographyVariants.caption} display={TypographyDisplay.inline} />
       <Typography label="label " variant={TypographyVariants.label} display={TypographyDisplay.inline} />
       <Typography label="overline " variant={TypographyVariants.overline} display={TypographyDisplay.inline} />
+    </div>
+  </StoriesWrapper>
+);
+
+export const Loading = () => (
+  <StoriesWrapper>
+    <div className="typography-wrapper">
+      <Typography loading />
     </div>
   </StoriesWrapper>
 );

--- a/src/components/Typography/index.tsx
+++ b/src/components/Typography/index.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from "react";
-import MUITypography from "@material-ui/core/Typography";
+import { Skeleton as MUISkeleton } from "@material-ui/lab";
+import { Typography as MUITypography } from "@material-ui/core";
 import { BaseIntlType } from "../../types/Base";
 import { TypographyType, TypographyVariants, TypographyDisplay } from "../../types/Typography";
 import withIntl from "../../utils/hocs/withIntl";
@@ -12,6 +13,7 @@ const Typography: FC<TypographyType> = ({
   bottomSpacing = undefined,
   dataCy = "typography",
   label,
+  loading = false,
   truncated = undefined,
   variant = TypographyVariants.body,
   display = TypographyDisplay.default,
@@ -25,7 +27,7 @@ const Typography: FC<TypographyType> = ({
       variantMapping={VARIANT_COMPONENT_MAP}
       display={display}
     >
-      {label}
+      {loading ? <MUISkeleton /> : label}
     </MUITypography>
   );
 };

--- a/src/types/Avatar.ts
+++ b/src/types/Avatar.ts
@@ -1,4 +1,4 @@
-import { BaseType } from "./Base";
+import { LoadableType } from "./Base";
 import { Icons } from "./Icon";
 
 export enum AvatarVariant {
@@ -7,7 +7,7 @@ export enum AvatarVariant {
   squared = "square",
 }
 
-export interface AvatarType extends BaseType {
+export interface AvatarType extends LoadableType {
   alt?: string;
   icon?: Icons;
   src?: string;

--- a/src/types/Base.ts
+++ b/src/types/Base.ts
@@ -13,3 +13,7 @@ export interface BaseType {
 export interface BaseIntlType extends BaseType {
   labelId: string;
 }
+
+export interface LoadableType extends BaseType {
+  loading?: boolean;
+}

--- a/src/types/Card.ts
+++ b/src/types/Card.ts
@@ -1,8 +1,8 @@
-import { BaseType } from "./Base";
+import { LoadableType } from "./Base";
 import { Icons } from "./Icon";
 import { ReactElement } from "react";
 
-export interface CardType extends BaseType {
+export interface CardType extends LoadableType {
   actions?: ReactElement[];
   collapsible?: ReactElement;
   content: ReactElement;

--- a/src/types/Icon.ts
+++ b/src/types/Icon.ts
@@ -1,4 +1,4 @@
-import { BaseType } from "./Base";
+import { LoadableType } from "./Base";
 
 export enum Icons {
   account = "account",
@@ -53,7 +53,7 @@ interface IconForwardedType {
   ref?: any;
 }
 
-export interface IconType extends BaseType {
+export interface IconType extends LoadableType {
   forwarded?: IconForwardedType;
   name: Icons;
   size?: IconSize;

--- a/src/types/ListItem.ts
+++ b/src/types/ListItem.ts
@@ -1,0 +1,22 @@
+import { ReactElement } from "react";
+import { LoadableType } from "./Base";
+import { Icons } from "./Icon";
+import { TypographyVariants } from "./Typography";
+
+interface BaseListItemType extends LoadableType {
+  dense?: boolean;
+  onClick?: () => void;
+  selected?: boolean;
+  title: string | ReactElement;
+  titleVariant?: TypographyVariants;
+}
+
+export interface ListItemType extends BaseListItemType {
+  icon?: Icons;
+}
+
+export interface ListCollapsibleItemType extends BaseListItemType {
+  open?: boolean;
+  openTimeout?: "auto" | number;
+  unmountContent?: boolean;
+}

--- a/src/types/Typography.ts
+++ b/src/types/Typography.ts
@@ -1,4 +1,4 @@
-import { BaseType } from "./Base";
+import { LoadableType } from "./Base";
 
 export enum TypographyVariants {
   body = "body1",
@@ -15,7 +15,7 @@ export enum TypographyDisplay {
   inline = "inline",
 }
 
-export interface TypographyType extends BaseType {
+export interface TypographyType extends LoadableType {
   bottomSpacing?: boolean;
   label?: string;
   truncated?: boolean;


### PR DESCRIPTION
This PR adds two ListItem components that can be combined to render a complex list (using `List` from `@material-ui/core` as wrapper).

**ListItem**
<img width="457" alt="Screen Shot 2020-05-28 at 18 01 56" src="https://user-images.githubusercontent.com/61870694/83165144-689d2f80-a10d-11ea-9c86-e7c91c40574e.png">

**ListCollapsibleItem**
<img width="455" alt="Screen Shot 2020-05-28 at 18 02 19" src="https://user-images.githubusercontent.com/61870694/83165171-6e931080-a10d-11ea-8982-51197e1f3ab2.png">
