### PR TITLE
Implement Select component

### DIFF
--- a/src/components/Select/index.stories.tsx
+++ b/src/components/Select/index.stories.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import { boolean, text } from "@storybook/addon-knobs";
+import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
+import Select from ".";
+
+export default {
+  title: "Select",
+  component: Select,
+  parameters: {
+    ...getDocsPageStructure("Select"),
+  },
+};
+
+type DataType = {
+  name: string;
+  type: "CARS" | "TRUCKS";
+};
+
+const value = { name: "", type: "CARS" };
+
+const options: DataType[] = [
+  { name: "Fiat", type: "CARS" },
+  { name: "Ford", type: "CARS" },
+  { name: "Chevrolet", type: "CARS" },
+  { name: "Opel", type: "CARS" },
+  { name: "Peugeot", type: "CARS" },
+  { name: "Abart", type: "CARS" },
+  { name: "Ferrari", type: "CARS" },
+  { name: "Honda", type: "CARS" },
+  { name: "Suzuki", type: "CARS" },
+  { name: "Mercedes", type: "CARS" },
+  { name: "Iveco", type: "TRUCKS" },
+  { name: "Scania", type: "TRUCKS" },
+  { name: "Opel", type: "TRUCKS" },
+  { name: "Mercedes", type: "TRUCKS" },
+];
+
+export const Canvas = () => (
+  <Select
+    autoComplete={boolean("autoComplete", true)}
+    disabled={boolean("disabled", false)}
+    getGroupLabel={(groupName) => groupName.toLowerCase()}
+    getOptionLabel={(option) => option.name}
+    groupBy={(option) => option.type}
+    label={text("label", "Label")}
+    loading={boolean("loading", false)}
+    multiple={false}
+    onChange={action("On Change")}
+    options={options}
+    value={value}
+  />
+);
+
+// export const OtherStories = () => (
+//   <StoriesWrapper>
+//     <Select />
+//   </StoriesWrapper>
+// );

--- a/src/components/Select/index.stories.tsx
+++ b/src/components/Select/index.stories.tsx
@@ -12,48 +12,86 @@ export default {
   },
 };
 
-type DataType = {
-  name: string;
-  type: "CARS" | "TRUCKS";
-};
-
-const value = { name: "", type: "CARS" };
-
-const options: DataType[] = [
-  { name: "Fiat", type: "CARS" },
-  { name: "Ford", type: "CARS" },
-  { name: "Chevrolet", type: "CARS" },
-  { name: "Opel", type: "CARS" },
-  { name: "Peugeot", type: "CARS" },
-  { name: "Abart", type: "CARS" },
-  { name: "Ferrari", type: "CARS" },
-  { name: "Honda", type: "CARS" },
-  { name: "Suzuki", type: "CARS" },
-  { name: "Mercedes", type: "CARS" },
-  { name: "Iveco", type: "TRUCKS" },
-  { name: "Scania", type: "TRUCKS" },
-  { name: "Opel", type: "TRUCKS" },
-  { name: "Mercedes", type: "TRUCKS" },
-];
-
 export const Canvas = () => (
   <Select
     autoComplete={boolean("autoComplete", true)}
     disabled={boolean("disabled", false)}
-    getGroupLabel={(groupName) => groupName.toLowerCase()}
-    getOptionLabel={(option) => option.name}
-    groupBy={(option) => option.type}
     label={text("label", "Label")}
     loading={boolean("loading", false)}
-    multiple={false}
+    multiple={boolean("multiple", false)}
     onChange={action("On Change")}
-    options={options}
-    value={value}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
   />
 );
 
-// export const OtherStories = () => (
-//   <StoriesWrapper>
-//     <Select />
-//   </StoriesWrapper>
-// );
+export const Basic = () => (
+  <Select
+    label="Arts & Creativity"
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const Disabled = () => (
+  <Select
+    disabled
+    label="Arts & Creativity"
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const Multiple = () => (
+  <Select
+    label="Arts & Creativity"
+    multiple
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const Grouped = () => (
+  <Select
+    groupBy={(option) => option.slice(0, 1)}
+    label="Arts & Creativity"
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const InitialValue = () => (
+  <Select
+    initialValue="Mosaic"
+    label="Arts & Creativity"
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const Loading = () => (
+  <Select
+    label="Arts & Creativity"
+    loading
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const WithCustomGroupLabel = () => (
+  <Select
+    getGroupLabel={(groupName) => `Letter: ${groupName}`}
+    groupBy={(option) => option.slice(0, 1)}
+    label="Arts & Creativity"
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const WithCustomOptionRendering = () => (
+  <Select
+    customOptionRendering={(option) => <b>{option.slice(0, 3).toUpperCase()}</b>}
+    label="Arts & Creativity"
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);

--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { mount } from "enzyme";
+import Select from ".";
+
+const defaultProps = {
+  autocomplete: true,
+  label: "Label",
+  onChange: () => {},
+  options: ["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"],
+};
+
+const componentWrapper = (props = {}) => <Select {...defaultProps} {...props} />;
+
+describe("Select test suite:", () => {
+  it("default", () => {
+    const component = componentWrapper();
+    const wrapper = mount(component);
+  });
+
+  it("disabled", () => {
+    const component = componentWrapper({ disabled: true });
+    const wrapper = mount(component);
+  });
+
+  it("grouped", () => {
+    const component = componentWrapper({ groupBy: (option: string) => option.slice(0, 1) });
+    const wrapper = mount(component);
+  });
+
+  it("loading", () => {
+    const component = componentWrapper({ loading: true });
+    const wrapper = mount(component);
+  });
+
+  it("multiple", () => {
+    const component = componentWrapper({ multiple: true });
+    const wrapper = mount(component);
+  });
+
+  it("multiple with initial", () => {
+    const component = componentWrapper({ initialValue: ["Mosaic"], multiple: true });
+    const wrapper = mount(component);
+  });
+
+  it("with custom group name", () => {
+    const component = componentWrapper({
+      groupBy: (option: string) => option.slice(0, 1),
+      getGroupLabel: (groupName: string) => groupName.toUpperCase(),
+    });
+    const wrapper = mount(component);
+  });
+
+  it("with custom option label", () => {
+    const component = componentWrapper({ getOptionLabel: (option: string) => option.toUpperCase() });
+    const wrapper = mount(component);
+  });
+
+  it("with custom option rendering", () => {
+    const component = componentWrapper({ customOptionRendering: (option: string) => <b>{option}</b> });
+    const wrapper = mount(component);
+  });
+
+  it("with initial", () => {
+    const component = componentWrapper({ initialValue: "Mosaic" });
+    const wrapper = mount(component);
+  });
+
+  it("with invalid initial", () => {
+    const component = componentWrapper({ initialValue: ["Mosaic"] });
+    const wrapper = mount(component);
+  });
+});

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,10 +1,8 @@
 import React, { Fragment } from "react";
-import { TextField as MUITextField, useTheme } from "@material-ui/core";
+import { TextField as MUITextField } from "@material-ui/core";
 import { Autocomplete as MUIAutocomplete, Skeleton as MUISkeleton } from "@material-ui/lab";
-import Icon from "../Icon";
-import Spacer from "../Spacer";
+import Checkbox from "../Checkbox";
 import Typography from "../Typography";
-import { Icons } from "../../types/Icon";
 import { InputVariant } from "../../types/Input";
 import { SelectType } from "../../types/Select";
 import { suppressEvent } from "../../utils";
@@ -14,7 +12,7 @@ import { StyledMUIListSubheader } from "./styled";
  * Select component made on top of `@material-ui/core/Autocomplete`
  */
 
-const Select = <T extends object>({
+const Select = <T extends any>({
   autoComplete = true,
   customOptionRendering = undefined,
   dataCy = "select",
@@ -23,19 +21,23 @@ const Select = <T extends object>({
   getOptionLabel,
   getOptionSelected = undefined,
   groupBy = undefined,
+  initialValue = null,
   label = undefined,
   loading = false,
   multiple = false,
   onChange,
   options,
-  value = null,
 }: SelectType<T>) => {
+  const defaultValue = options.some((option) => option === initialValue) ? initialValue : null;
+  const getLabel = (option: T): string => (getOptionLabel ? getOptionLabel(option) : option.toString());
+
   return (
     <MUIAutocomplete<T, boolean>
       autoComplete={autoComplete}
+      defaultValue={defaultValue}
       disableCloseOnSelect={false}
       disabled={disabled}
-      getOptionLabel={getOptionLabel}
+      getOptionLabel={getLabel}
       getOptionSelected={(option, value) => {
         if (getOptionSelected) {
           return getOptionSelected(option, value);
@@ -52,8 +54,8 @@ const Select = <T extends object>({
         onChange(value);
       }}
       options={options.sort((one: T, another: T) => {
-        const oneLabel = getOptionLabel(one);
-        const anotherLabel = getOptionLabel(another);
+        const oneLabel = getLabel(one);
+        const anotherLabel = getLabel(another);
         const labelSorting = oneLabel.localeCompare(anotherLabel);
         if (!groupBy) {
           return labelSorting;
@@ -88,19 +90,18 @@ const Select = <T extends object>({
           return customOptionRendering(option, selected);
         }
 
-        const optionLabel = getOptionLabel(option);
+        const optionLabel = getLabel(option);
         return (
           <Fragment key={`option-${optionLabel}`}>
-            <Icon
-              dataCy={`${dataCy}-option option-icon-${optionLabel}`}
-              name={selected ? Icons.checkbox : Icons.checkbox_empty}
+            <Checkbox dataCy={`${dataCy}-option option-checkbox-${optionLabel}`} disabled value={selected} />
+            <Typography
+              bottomSpacing={false}
+              dataCy={`${dataCy}-option option-label-${optionLabel}`}
+              label={optionLabel}
             />
-            <Spacer level={2} />
-            <Typography dataCy={`${dataCy}-option option-label-${optionLabel}`} label={optionLabel} />
           </Fragment>
         );
       }}
-      value={options.some((opt) => opt === value) ? value : null}
     />
   );
 };

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -28,13 +28,32 @@ const Select = <T extends any>({
   onChange,
   options,
 }: SelectType<T>) => {
-  const defaultValue = options.some((option) => option === initialValue) ? initialValue : null;
+  const getDefaultValue = () => {
+    const INVALID_INITIAL_VALUE_WARNING = "[@melfore/mosaic] Select: initialValue is invalid, will be ignored!";
+    const valueIsIncluded = (value: T | null) => !!value && options.some((option) => option === value);
+    if (!multiple) {
+      if (Array.isArray(initialValue)) {
+        console.warn(INVALID_INITIAL_VALUE_WARNING);
+        return null;
+      }
+
+      return valueIsIncluded(initialValue) ? initialValue : null;
+    }
+
+    if (!Array.isArray(initialValue)) {
+      console.warn(INVALID_INITIAL_VALUE_WARNING);
+      return [];
+    }
+
+    return initialValue.every(valueIsIncluded) ? initialValue : [];
+  };
+
   const getLabel = (option: T): string => (getOptionLabel ? getOptionLabel(option) : option.toString());
 
   return (
     <MUIAutocomplete<T, boolean>
       autoComplete={autoComplete}
-      defaultValue={defaultValue}
+      defaultValue={getDefaultValue()}
       disableCloseOnSelect={false}
       disabled={disabled}
       getOptionLabel={getLabel}

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,0 +1,108 @@
+import React, { Fragment } from "react";
+import { TextField as MUITextField, useTheme } from "@material-ui/core";
+import { Autocomplete as MUIAutocomplete, Skeleton as MUISkeleton } from "@material-ui/lab";
+import Icon from "../Icon";
+import Spacer from "../Spacer";
+import Typography from "../Typography";
+import { Icons } from "../../types/Icon";
+import { InputVariant } from "../../types/Input";
+import { SelectType } from "../../types/Select";
+import { suppressEvent } from "../../utils";
+import { StyledMUIListSubheader } from "./styled";
+
+/**
+ * Select component made on top of `@material-ui/core/Autocomplete`
+ */
+
+const Select = <T extends object>({
+  autoComplete = true,
+  customOptionRendering = undefined,
+  dataCy = "select",
+  disabled = false,
+  getGroupLabel = undefined,
+  getOptionLabel,
+  getOptionSelected = undefined,
+  groupBy = undefined,
+  label = undefined,
+  loading = false,
+  multiple = false,
+  onChange,
+  options,
+  value = null,
+}: SelectType<T>) => {
+  return (
+    <MUIAutocomplete<T, boolean>
+      autoComplete={autoComplete}
+      disableCloseOnSelect={false}
+      disabled={disabled}
+      getOptionLabel={getOptionLabel}
+      getOptionSelected={(option, value) => {
+        if (getOptionSelected) {
+          return getOptionSelected(option, value);
+        }
+
+        return !!value && option === value;
+      }}
+      groupBy={groupBy}
+      ListboxProps={{ style: { padding: 0 } }}
+      loading={loading}
+      multiple={multiple}
+      onChange={(event, value) => {
+        suppressEvent(event);
+        onChange(value);
+      }}
+      options={options.sort((one: T, another: T) => {
+        const oneLabel = getOptionLabel(one);
+        const anotherLabel = getOptionLabel(another);
+        const labelSorting = oneLabel.localeCompare(anotherLabel);
+        if (!groupBy) {
+          return labelSorting;
+        }
+
+        const oneGroup = groupBy(one);
+        const anotherGroup = groupBy(another);
+        return oneGroup.localeCompare(anotherGroup) || labelSorting;
+      })}
+      renderGroup={(groupProps) => {
+        const { children, group, key } = groupProps;
+        const groupLabel = getGroupLabel ? getGroupLabel(group) : group;
+        return (
+          <Fragment key={`group-${key}`}>
+            <StyledMUIListSubheader>{groupLabel}</StyledMUIListSubheader>
+            {children}
+          </Fragment>
+        );
+      }}
+      renderInput={(inputProps) => {
+        const { inputProps: extInputProps } = inputProps;
+        const forwardedInputProps = { ...inputProps, inputProps: { ...extInputProps, "data-cy": `${dataCy}-select` } };
+        const inputComponent = <MUITextField {...forwardedInputProps} label={label} variant={InputVariant.default} />;
+        if (loading) {
+          return <MUISkeleton width="100%">{inputComponent}</MUISkeleton>;
+        }
+
+        return inputComponent;
+      }}
+      renderOption={(option, { selected }) => {
+        if (customOptionRendering) {
+          return customOptionRendering(option, selected);
+        }
+
+        const optionLabel = getOptionLabel(option);
+        return (
+          <Fragment key={`option-${optionLabel}`}>
+            <Icon
+              dataCy={`${dataCy}-option option-icon-${optionLabel}`}
+              name={selected ? Icons.checkbox : Icons.checkbox_empty}
+            />
+            <Spacer level={2} />
+            <Typography dataCy={`${dataCy}-option option-label-${optionLabel}`} label={optionLabel} />
+          </Fragment>
+        );
+      }}
+      value={options.some((opt) => opt === value) ? value : null}
+    />
+  );
+};
+
+export default Select;

--- a/src/components/Select/styled.ts
+++ b/src/components/Select/styled.ts
@@ -1,0 +1,5 @@
+import { ListSubheader as MUIListSubheader, styled } from "@material-ui/core";
+
+export const StyledMUIListSubheader = styled(MUIListSubheader)(({ theme }) => ({
+  backgroundColor: theme.palette.background.default,
+}));

--- a/src/types/Select.ts
+++ b/src/types/Select.ts
@@ -1,0 +1,17 @@
+import { LoadableType } from "./Base";
+import { ReactNode } from "react";
+
+export interface SelectType<T> extends LoadableType {
+  autoComplete?: boolean;
+  customOptionRendering?: (option: T, selected: boolean) => ReactNode;
+  disabled?: boolean;
+  getGroupLabel?: (groupName: string) => string;
+  getOptionLabel: (option: T) => string;
+  getOptionSelected?: (option: T, value: T) => boolean;
+  groupBy?: (option: T) => string;
+  label?: string;
+  multiple?: boolean;
+  onChange: (value: T | T[] | null) => void;
+  options: T[];
+  value: T | T[] | null;
+}

--- a/src/types/Select.ts
+++ b/src/types/Select.ts
@@ -6,12 +6,12 @@ export interface SelectType<T> extends LoadableType {
   customOptionRendering?: (option: T, selected: boolean) => ReactNode;
   disabled?: boolean;
   getGroupLabel?: (groupName: string) => string;
-  getOptionLabel: (option: T) => string;
+  getOptionLabel?: (option: T) => string;
   getOptionSelected?: (option: T, value: T) => boolean;
   groupBy?: (option: T) => string;
+  initialValue?: T | T[] | null;
   label?: string;
   multiple?: boolean;
   onChange: (value: T | T[] | null) => void;
   options: T[];
-  value: T | T[] | null;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
-import { MouseEvent } from "react";
+import { ChangeEvent, MouseEvent } from "react";
 
-export const suppressEvent = (event: MouseEvent) => {
+export const suppressEvent = (event: ChangeEvent<any> | MouseEvent) => {
   event.preventDefault();
   event.stopPropagation();
 };


### PR DESCRIPTION
This PR fixes #27 by adding Select component.

It is built upon `Autocomplete` from `@material-ui/lab`, including the following features:
- autocomplete
- customized options (labels and rendering)
- disable state
- groups (with custom labels)
- initialValue provisioning (with validation against multiple selection)
- loading
- multiple selection

Compromise was taken on code coverage: it is now barely acceptable, it performs only rendering tests on several cases with no detailed assertions. Will be implemented later on but however meets predefined thresholds.