### PR TITLE
Select component improvements

### DIFF
--- a/src/components/InputText/index.test.tsx
+++ b/src/components/InputText/index.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import InputText, { InputTextIntl } from ".";
 import IntlProviderMock, { LocaleMock, MessageMock, mockedMessages } from "../../utils/mocks/IntlProviderMock";
+import { Icons } from "../../types/Icon";
 
 const defaultProps = {
   dataCy: "input-text",
@@ -46,6 +47,26 @@ describe("InputText test suite:", () => {
     const input = wrapper.find("input");
     input.simulate("change");
     expect(onChangeHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("with adornment", () => {
+    const component = componentWrapper({
+      adornment: {
+        icon: Icons.search,
+      },
+    });
+    const wrapper = mount(component);
+  });
+
+  it("with clickable adornment", () => {
+    const onAdornmentClick = jest.fn();
+    const component = componentWrapper({
+      adornment: {
+        icon: Icons.search,
+        onClick: onAdornmentClick,
+      },
+    });
+    const wrapper = mount(component);
   });
 
   it("with intl", () => {

--- a/src/components/Select/index.stories.tsx
+++ b/src/components/Select/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import { boolean, text } from "@storybook/addon-knobs";
+import { boolean, text, number } from "@storybook/addon-knobs";
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Select from ".";
 import { InputSize, InputVariant } from "../../types/Input";
@@ -16,13 +16,13 @@ export default {
 export const Canvas = () => (
   <Select
     autoComplete={boolean("autoComplete", true)}
-    customPopperWidth={text("customPopperWidth", "100%")}
     disabled={boolean("disabled", false)}
     label={text("label", "Label")}
     loading={boolean("loading", false)}
     multiple={boolean("multiple", false)}
     onChange={action("On Change")}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+    popperWidth={number("popperWidth", 300)}
   />
 );
 

--- a/src/components/Select/index.stories.tsx
+++ b/src/components/Select/index.stories.tsx
@@ -3,6 +3,7 @@ import { action } from "@storybook/addon-actions";
 import { boolean, text } from "@storybook/addon-knobs";
 import { getDocsPageStructure, StoriesWrapper } from "../../utils/stories";
 import Select from ".";
+import { InputSize, InputVariant } from "../../types/Input";
 
 export default {
   title: "Select",
@@ -27,6 +28,7 @@ export const Canvas = () => (
 export const Basic = () => (
   <Select
     label="Arts & Creativity"
+    multiple={false}
     onChange={(value) => {}}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
   />
@@ -36,6 +38,7 @@ export const Disabled = () => (
   <Select
     disabled
     label="Arts & Creativity"
+    multiple={false}
     onChange={(value) => {}}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
   />
@@ -54,6 +57,7 @@ export const Grouped = () => (
   <Select
     groupBy={(option) => option.slice(0, 1)}
     label="Arts & Creativity"
+    multiple={false}
     onChange={(value) => {}}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
   />
@@ -61,10 +65,11 @@ export const Grouped = () => (
 
 export const InitialValue = () => (
   <Select
-    initialValue="Mosaic"
     label="Arts & Creativity"
+    multiple={false}
     onChange={(value) => {}}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+    value="Mosaic"
   />
 );
 
@@ -72,8 +77,39 @@ export const Loading = () => (
   <Select
     label="Arts & Creativity"
     loading
+    multiple={false}
     onChange={(value) => {}}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+  />
+);
+
+export const Required = () => (
+  <Select
+    label="Arts & Creativity"
+    multiple={false}
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+    required
+  />
+);
+
+export const Small = () => (
+  <Select
+    label="Arts & Creativity"
+    multiple={false}
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+    size={InputSize.small}
+  />
+);
+
+export const Variant = () => (
+  <Select
+    label="Arts & Creativity"
+    multiple={false}
+    onChange={(value) => {}}
+    options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
+    variant={InputVariant.filled}
   />
 );
 
@@ -82,6 +118,7 @@ export const WithCustomGroupLabel = () => (
     getGroupLabel={(groupName) => `Letter: ${groupName}`}
     groupBy={(option) => option.slice(0, 1)}
     label="Arts & Creativity"
+    multiple={false}
     onChange={(value) => {}}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
   />
@@ -91,6 +128,7 @@ export const WithCustomOptionRendering = () => (
   <Select
     customOptionRendering={(option) => <b>{option.slice(0, 3).toUpperCase()}</b>}
     label="Arts & Creativity"
+    multiple={false}
     onChange={(value) => {}}
     options={["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]}
   />

--- a/src/components/Select/index.stories.tsx
+++ b/src/components/Select/index.stories.tsx
@@ -16,6 +16,7 @@ export default {
 export const Canvas = () => (
   <Select
     autoComplete={boolean("autoComplete", true)}
+    customPopperWidth={text("customPopperWidth", "100%")}
     disabled={boolean("disabled", false)}
     label={text("label", "Label")}
     loading={boolean("loading", false)}

--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -5,6 +5,7 @@ import Select from ".";
 const defaultProps = {
   autocomplete: true,
   label: "Label",
+  multiple: false,
   onChange: () => {},
   options: ["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"],
 };
@@ -38,7 +39,7 @@ describe("Select test suite:", () => {
   });
 
   it("multiple with initial", () => {
-    const component = componentWrapper({ multiple: true, value: ["Mosaic"] });
+    const component = componentWrapper({ multiple: true, onChange: () => {}, value: ["Mosaic"] });
     const wrapper = mount(component);
   });
 
@@ -57,6 +58,11 @@ describe("Select test suite:", () => {
 
   it("with custom option rendering", () => {
     const component = componentWrapper({ customOptionRendering: (option: string) => <b>{option}</b> });
+    const wrapper = mount(component);
+  });
+
+  it("with custom popper width", () => {
+    const component = componentWrapper({ customPopperWidth: "500px" });
     const wrapper = mount(component);
   });
 

--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -62,7 +62,7 @@ describe("Select test suite:", () => {
   });
 
   it("with custom popper width", () => {
-    const component = componentWrapper({ customPopperWidth: "500px" });
+    const component = componentWrapper({ popperWidth: 500 });
     const wrapper = mount(component);
   });
 

--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -38,7 +38,7 @@ describe("Select test suite:", () => {
   });
 
   it("multiple with initial", () => {
-    const component = componentWrapper({ initialValue: ["Mosaic"], multiple: true });
+    const component = componentWrapper({ multiple: true, value: ["Mosaic"] });
     const wrapper = mount(component);
   });
 
@@ -61,12 +61,12 @@ describe("Select test suite:", () => {
   });
 
   it("with initial", () => {
-    const component = componentWrapper({ initialValue: "Mosaic" });
+    const component = componentWrapper({ value: "Mosaic" });
     const wrapper = mount(component);
   });
 
   it("with invalid initial", () => {
-    const component = componentWrapper({ initialValue: ["Mosaic"] });
+    const component = componentWrapper({ value: ["Mosaic"] });
     const wrapper = mount(component);
   });
 });

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from "react";
-import { Popper, useTheme, PopperProps } from "@material-ui/core";
+import { Popper, PopperProps } from "@material-ui/core";
 import { Autocomplete as MUIAutocomplete, Skeleton as MUISkeleton } from "@material-ui/lab";
 import Checkbox from "../Checkbox";
 import Typography from "../Typography";
@@ -15,7 +15,6 @@ import { StyledMUIListSubheader, StyledMUITextField } from "./styled";
 const Select = <T extends any>({
   autoComplete = true,
   customOptionRendering = undefined,
-  customPopperWidth = undefined,
   dataCy = "select",
   disabled = false,
   getGroupLabel = undefined,
@@ -28,18 +27,13 @@ const Select = <T extends any>({
   onChange,
   options,
   placeholder = undefined,
+  popperWidth = undefined,
   required = false,
   size = InputSize.default,
   type = InputDataType.default,
   value = null,
   variant = InputVariant.default,
 }: SelectType<T>) => {
-  const theme = useTheme();
-  let optionsWidth = `calc(100% - ${theme.spacing(2)}px)`;
-  if (!!customPopperWidth) {
-    optionsWidth = customPopperWidth;
-  }
-
   const getLabel = (option: T): string => (getOptionLabel ? getOptionLabel(option) : option.toString());
 
   const isSelected = (option: T, value: T): boolean => {
@@ -89,9 +83,13 @@ const Select = <T extends any>({
         const anotherGroup = groupBy(another);
         return oneGroup.localeCompare(anotherGroup) || labelSorting;
       })}
-      PopperComponent={(props: PopperProps) => (
-        <Popper {...props} placement="bottom-start" style={{ width: optionsWidth }} />
-      )}
+      PopperComponent={(props: PopperProps) => {
+        const { anchorEl } = props;
+        const anchorElRef = anchorEl as any;
+        const anchorElWidth = anchorElRef ? anchorElRef.clientWidth : null;
+        const width = !!popperWidth && popperWidth > anchorElWidth ? popperWidth : anchorElWidth;
+        return <Popper {...props} placement="bottom-start" style={{ width }} />;
+      }}
       renderGroup={(groupProps) => {
         const { children, group, key } = groupProps;
         const groupLabel = getGroupLabel ? getGroupLabel(group) : group;

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,12 +1,11 @@
 import React, { Fragment } from "react";
-import { TextField as MUITextField } from "@material-ui/core";
 import { Autocomplete as MUIAutocomplete, Skeleton as MUISkeleton } from "@material-ui/lab";
 import Checkbox from "../Checkbox";
 import Typography from "../Typography";
-import { InputVariant } from "../../types/Input";
+import { InputVariant, InputSize, InputDataType } from "../../types/Input";
 import { SelectType } from "../../types/Select";
 import { suppressEvent } from "../../utils";
-import { StyledMUIListSubheader } from "./styled";
+import { StyledMUIListSubheader, StyledMUITextField } from "./styled";
 
 /**
  * Select component made on top of `@material-ui/core/Autocomplete`
@@ -21,54 +20,52 @@ const Select = <T extends any>({
   getOptionLabel,
   getOptionSelected = undefined,
   groupBy = undefined,
-  initialValue = null,
   label = undefined,
   loading = false,
   multiple = false,
   onChange,
   options,
+  placeholder = undefined,
+  required = false,
+  size = InputSize.default,
+  type = InputDataType.default,
+  value = null,
+  variant = InputVariant.default,
 }: SelectType<T>) => {
-  const getDefaultValue = () => {
-    const INVALID_INITIAL_VALUE_WARNING = "[@melfore/mosaic] Select: initialValue is invalid, will be ignored!";
-    const valueIsIncluded = (value: T | null) => !!value && options.some((option) => option === value);
-    if (!multiple) {
-      if (Array.isArray(initialValue)) {
-        console.warn(INVALID_INITIAL_VALUE_WARNING);
-        return null;
-      }
+  const getLabel = (option: T): string => (getOptionLabel ? getOptionLabel(option) : option.toString());
 
-      return valueIsIncluded(initialValue) ? initialValue : null;
+  const isSelected = (option: T, value: T): boolean => {
+    if (getOptionSelected) {
+      return getOptionSelected(option, value);
     }
 
-    if (!Array.isArray(initialValue)) {
-      console.warn(INVALID_INITIAL_VALUE_WARNING);
-      return [];
-    }
-
-    return initialValue.every(valueIsIncluded) ? initialValue : [];
+    return !!value && option === value;
   };
 
-  const getLabel = (option: T): string => (getOptionLabel ? getOptionLabel(option) : option.toString());
+  const isSelectable = (value: T | null): boolean => !!value && options.some((option) => isSelected(option, value));
+
+  const validateValue = (value: T | T[] | null): T | T[] | null => {
+    if (multiple) {
+      const isValidMultipleValue = Array.isArray(value) && value.length > 0 && value.every(isSelectable);
+      return isValidMultipleValue ? value : [];
+    }
+
+    const isValidValue = !Array.isArray(value) && isSelectable(value);
+    return isValidValue ? value : null;
+  };
 
   return (
     <MUIAutocomplete<T, boolean>
       autoComplete={autoComplete}
-      defaultValue={getDefaultValue()}
-      disableCloseOnSelect={false}
+      disableCloseOnSelect={multiple}
       disabled={disabled}
       getOptionLabel={getLabel}
-      getOptionSelected={(option, value) => {
-        if (getOptionSelected) {
-          return getOptionSelected(option, value);
-        }
-
-        return !!value && option === value;
-      }}
+      getOptionSelected={isSelected}
       groupBy={groupBy}
       ListboxProps={{ style: { padding: 0 } }}
       loading={loading}
       multiple={multiple}
-      onChange={(event, value) => {
+      onChange={(event, value: any) => {
         suppressEvent(event);
         onChange(value);
       }}
@@ -97,7 +94,18 @@ const Select = <T extends any>({
       renderInput={(inputProps) => {
         const { inputProps: extInputProps } = inputProps;
         const forwardedInputProps = { ...inputProps, inputProps: { ...extInputProps, "data-cy": `${dataCy}-select` } };
-        const inputComponent = <MUITextField {...forwardedInputProps} label={label} variant={InputVariant.default} />;
+        const inputComponent = (
+          <StyledMUITextField
+            {...forwardedInputProps}
+            label={label}
+            margin="normal"
+            placeholder={placeholder}
+            required={required}
+            size={size}
+            type={type}
+            variant={variant}
+          />
+        );
         if (loading) {
           return <MUISkeleton width="100%">{inputComponent}</MUISkeleton>;
         }
@@ -121,6 +129,7 @@ const Select = <T extends any>({
           </Fragment>
         );
       }}
+      value={validateValue(value)}
     />
   );
 };

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from "react";
+import { Popper, useTheme, PopperProps } from "@material-ui/core";
 import { Autocomplete as MUIAutocomplete, Skeleton as MUISkeleton } from "@material-ui/lab";
 import Checkbox from "../Checkbox";
 import Typography from "../Typography";
@@ -14,6 +15,7 @@ import { StyledMUIListSubheader, StyledMUITextField } from "./styled";
 const Select = <T extends any>({
   autoComplete = true,
   customOptionRendering = undefined,
+  customPopperWidth = undefined,
   dataCy = "select",
   disabled = false,
   getGroupLabel = undefined,
@@ -32,6 +34,12 @@ const Select = <T extends any>({
   value = null,
   variant = InputVariant.default,
 }: SelectType<T>) => {
+  const theme = useTheme();
+  let optionsWidth = `calc(100% - ${theme.spacing(2)}px)`;
+  if (!!customPopperWidth) {
+    optionsWidth = customPopperWidth;
+  }
+
   const getLabel = (option: T): string => (getOptionLabel ? getOptionLabel(option) : option.toString());
 
   const isSelected = (option: T, value: T): boolean => {
@@ -62,7 +70,7 @@ const Select = <T extends any>({
       getOptionLabel={getLabel}
       getOptionSelected={isSelected}
       groupBy={groupBy}
-      ListboxProps={{ style: { padding: 0 } }}
+      ListboxProps={{ style: { padding: 0, width: "100%" } }}
       loading={loading}
       multiple={multiple}
       onChange={(event, value: any) => {
@@ -81,6 +89,9 @@ const Select = <T extends any>({
         const anotherGroup = groupBy(another);
         return oneGroup.localeCompare(anotherGroup) || labelSorting;
       })}
+      PopperComponent={(props: PopperProps) => (
+        <Popper {...props} placement="bottom-start" style={{ width: optionsWidth }} />
+      )}
       renderGroup={(groupProps) => {
         const { children, group, key } = groupProps;
         const groupLabel = getGroupLabel ? getGroupLabel(group) : group;

--- a/src/components/Select/styled.ts
+++ b/src/components/Select/styled.ts
@@ -1,5 +1,9 @@
-import { ListSubheader as MUIListSubheader, styled } from "@material-ui/core";
+import { ListSubheader as MUIListSubheader, TextField as MUITextField, styled } from "@material-ui/core";
 
 export const StyledMUIListSubheader = styled(MUIListSubheader)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
 }));
+
+export const StyledMUITextField = styled(MUITextField)({
+  width: "100%",
+});

--- a/src/types/Input.ts
+++ b/src/types/Input.ts
@@ -13,6 +13,7 @@ export enum InputDataType {
 export enum InputVariant {
   default = "outlined",
   filled = "filled",
+  underlined = "standard",
 }
 
 export interface InputType extends BaseType {

--- a/src/types/Select.ts
+++ b/src/types/Select.ts
@@ -5,6 +5,7 @@ import { InputType } from "./Input";
 interface BaseSelectType<T> extends LoadableType, InputType {
   autoComplete?: boolean;
   customOptionRendering?: (option: T, selected: boolean) => ReactNode;
+  customPopperWidth?: string;
   getGroupLabel?: (groupName: string) => string;
   getOptionLabel?: (option: T) => string;
   getOptionSelected?: (option: T, value: T) => boolean;
@@ -12,16 +13,20 @@ interface BaseSelectType<T> extends LoadableType, InputType {
   options: T[];
 }
 
+type SingleSelectDataType<T> = T | null;
+
 interface SingleSelectType<T> extends BaseSelectType<T> {
   multiple: false;
-  onChange: (value: T | null) => void;
-  value?: T | null;
+  onChange: (value: SingleSelectDataType<T>) => void;
+  value?: SingleSelectDataType<T>;
 }
+
+type MultipleSelectDataType<T> = T[] | null;
 
 interface MultipleSelectType<T> extends BaseSelectType<T> {
   multiple: true;
-  onChange: (value: T[] | null) => void;
-  value?: T[] | null;
+  onChange: (value: MultipleSelectDataType<T>) => void;
+  value?: MultipleSelectDataType<T>;
 }
 
 export type SelectType<T> = SingleSelectType<T> | MultipleSelectType<T>;

--- a/src/types/Select.ts
+++ b/src/types/Select.ts
@@ -5,12 +5,12 @@ import { InputType } from "./Input";
 interface BaseSelectType<T> extends LoadableType, InputType {
   autoComplete?: boolean;
   customOptionRendering?: (option: T, selected: boolean) => ReactNode;
-  customPopperWidth?: string;
   getGroupLabel?: (groupName: string) => string;
   getOptionLabel?: (option: T) => string;
   getOptionSelected?: (option: T, value: T) => boolean;
   groupBy?: (option: T) => string;
   options: T[];
+  popperWidth?: number;
 }
 
 type SingleSelectDataType<T> = T | null;

--- a/src/types/Select.ts
+++ b/src/types/Select.ts
@@ -1,17 +1,27 @@
-import { LoadableType } from "./Base";
 import { ReactNode } from "react";
+import { LoadableType } from "./Base";
+import { InputType } from "./Input";
 
-export interface SelectType<T> extends LoadableType {
+interface BaseSelectType<T> extends LoadableType, InputType {
   autoComplete?: boolean;
   customOptionRendering?: (option: T, selected: boolean) => ReactNode;
-  disabled?: boolean;
   getGroupLabel?: (groupName: string) => string;
   getOptionLabel?: (option: T) => string;
   getOptionSelected?: (option: T, value: T) => boolean;
   groupBy?: (option: T) => string;
-  initialValue?: T | T[] | null;
-  label?: string;
-  multiple?: boolean;
-  onChange: (value: T | T[] | null) => void;
   options: T[];
 }
+
+interface SingleSelectType<T> extends BaseSelectType<T> {
+  multiple: false;
+  onChange: (value: T | null) => void;
+  value?: T | null;
+}
+
+interface MultipleSelectType<T> extends BaseSelectType<T> {
+  multiple: true;
+  onChange: (value: T[] | null) => void;
+  value?: T[] | null;
+}
+
+export type SelectType<T> = SingleSelectType<T> | MultipleSelectType<T>;


### PR DESCRIPTION
This PR extends the features of the Select component done in #118.

In particular:

- makes `Select` always a stateless component (`value` prop should always arrive from outside)
- `Select` extends `BaseInput` type adding all the typical input props
- allows customization of width of the popup (aka `popper`) with `customPopperWidth` prop
- **[most important]** `SelectType` becomes dynamic looking at `multiple` prop