### PR TITLE
Fixed data-cy reference for Select

### DIFF
--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -53,7 +53,11 @@ describe("Select Single test suite:", () => {
   });
 
   it("loading", () => {
-    const { wrapper } = getSelectTestable({ ...defaultProps, loading: true }, DATA_CY_DEFAULT, "div");
+    const { wrapper } = getSelectTestable(
+      { ...defaultProps, loading: true },
+      `${DATA_CY_DEFAULT}-outer-wrapper`,
+      "div"
+    );
     const placeholder = wrapper.find("span.MuiSkeleton-root");
     expect(placeholder).toHaveLength(1);
   });

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -19,10 +19,6 @@ export const LOCALIZABLE_PROPS: ILocalizableProperty[] = [
 ];
 
 export const SUBPARTS_MAP = {
-  optionGroupLabel: {
-    label: "Option Group (with label)",
-    value: (label = "{label}") => `option-group-${label}`,
-  },
   loading: {
     label: "Loading",
   },
@@ -33,6 +29,13 @@ export const SUBPARTS_MAP = {
   optionLabel: {
     label: "Option Label (with label)",
     value: (label = "{label}") => `option-${label}-label`,
+  },
+  optionGroupLabel: {
+    label: "Option Group (with label)",
+    value: (label = "{label}") => `option-group-${label}`,
+  },
+  outerWrapper: {
+    label: "Outer Wrapper",
   },
 };
 
@@ -83,7 +86,7 @@ const Select = <T extends any>({
   return (
     <MUIAutocomplete<T, boolean>
       autoComplete={autoComplete}
-      data-cy={dataCy}
+      data-cy={getComposedDataCy(dataCy, SUBPARTS_MAP.outerWrapper)}
       disableCloseOnSelect={multiple}
       disabled={disabled}
       getOptionLabel={getLabel}
@@ -141,7 +144,7 @@ const Select = <T extends any>({
           );
         }
 
-        const forwardedInputProps = { ...inputProps, inputProps: { ...extInputProps, "data-cy": `${dataCy}` } };
+        const forwardedInputProps = { ...inputProps, inputProps: { ...extInputProps, "data-cy": dataCy } };
         return (
           <StyledMUITextField
             {...forwardedInputProps}


### PR DESCRIPTION
This PR closes #142  fixing the data-cy reference for Select.
The `Autocomplete` component can be spotted using `-outer-wrapper` suffix, while the default `data-cy` refers to the input.