### PR TITLE
Update Avatar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Add the package to your project with:
 It requires these `peerDependencies` to be installed in host project:
 
 ```
-  "@material-ui/core": ">= 4.11.0 < 5",
-  "@material-ui/icons": ">= 4.9.0 < 5",
-  "@material-ui/lab": ">= 4.0.0-alpha.56 < 5",
+  "@material-ui/core": ">= 4.11.3 < 5",
+  "@material-ui/icons": ">= 4.11.2 < 5",
+  "@material-ui/lab": ">= 4.0.0-alpha.57 < 5",
   "react": ">= 16.13.0 < 17",
   "react-dom": ">= 16.13.0 < 17",
   "react-intl": ">= 5.4.x < 6"

--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
     "typescript": "3.8.3"
   },
   "peerDependencies": {
-    "@material-ui/core": ">= 4.11.0 < 5",
-    "@material-ui/icons": ">= 4.9.0 < 5",
-    "@material-ui/lab": ">= 4.0.0-alpha.56 < 5",
+    "@material-ui/core": ">= 4.11.3 < 5",
+    "@material-ui/icons": ">= 4.11.2 < 5",
+    "@material-ui/lab": ">= 4.0.0-alpha.57 < 5",
     "react": ">= 16.13.0 < 17",
     "react-dom": ">= 16.13.0 < 17",
     "react-intl": ">= 5.4.x < 6"

--- a/src/components/Avatar/__snapshots__/index.test.tsx.snap
+++ b/src/components/Avatar/__snapshots__/index.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Avatar test suite: dataCy 1`] = `
 <div
-  className="MuiAvatar-root MuiAvatar-circle MuiAvatar-colorDefault"
+  className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault"
   data-cy="custom"
   style={
     Object {
@@ -15,7 +15,7 @@ exports[`Avatar test suite: dataCy 1`] = `
 
 exports[`Avatar test suite: default 1`] = `
 <div
-  className="MuiAvatar-root MuiAvatar-circle MuiAvatar-colorDefault"
+  className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault"
   data-cy="avatar"
   style={
     Object {
@@ -28,7 +28,7 @@ exports[`Avatar test suite: default 1`] = `
 
 exports[`Avatar test suite: icon 1`] = `
 <div
-  className="MuiAvatar-root MuiAvatar-circle MuiAvatar-colorDefault"
+  className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault"
   data-cy="avatar"
   style={
     Object {
@@ -53,7 +53,7 @@ exports[`Avatar test suite: icon 1`] = `
 
 exports[`Avatar test suite: image 1`] = `
 <div
-  className="MuiAvatar-root MuiAvatar-circle"
+  className="MuiAvatar-root MuiAvatar-circular"
   data-cy="avatar"
   style={
     Object {
@@ -113,7 +113,7 @@ exports[`Avatar test suite: squared 1`] = `
 
 exports[`Avatar test suite: text 1`] = `
 <div
-  className="MuiAvatar-root MuiAvatar-circle MuiAvatar-colorDefault"
+  className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault"
   data-cy="avatar"
   style={
     Object {

--- a/src/components/Card/__snapshots__/index.test.tsx.snap
+++ b/src/components/Card/__snapshots__/index.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`Card test suite: icon 1`] = `
       className="MuiCardHeader-avatar"
     >
       <div
-        className="MuiAvatar-root MuiAvatar-circle MuiAvatar-colorDefault"
+        className="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault"
         data-cy="card-avatar"
         style={
           Object {

--- a/src/types/Avatar.ts
+++ b/src/types/Avatar.ts
@@ -2,7 +2,7 @@ import { ILoadable } from "./Base";
 import { Icons } from "./Icon";
 
 export enum AvatarVariant {
-  default = "circle",
+  default = "circular",
   rounded = "rounded",
   squared = "square",
 }


### PR DESCRIPTION
This PR closes #178 removing deprecated `variant="circle"` for `Avatar` component.