### PR TITLE
fix: 🐛 [Table] Callback options to be optional

### DIFF
--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -21,7 +21,7 @@ export interface ITableDataCallbackOptions {
   multiple: boolean;
 }
 
-export type ITableDataCallback<T, K = any> = (data: K, options: ITableDataCallbackOptions) => T;
+export type ITableDataCallback<T, K = any> = (data: K, options?: ITableDataCallbackOptions) => T;
 
 export interface ITableAction extends IPartialIconUtilizer {
   /**


### PR DESCRIPTION
Setting callback options to be optional to ensure backward compatibility