### PR TITLE
[Select] Separate inner components

### DIFF
--- a/src/components/Select/components/Group/index.tsx
+++ b/src/components/Select/components/Group/index.tsx
@@ -1,0 +1,41 @@
+import React, { FC, Fragment, useMemo } from "react";
+import { ListSubheader as MUIListSubheader, useTheme } from "@material-ui/core";
+import { AutocompleteRenderGroupParams as MUIAutocompleteRenderGroupParams } from "@material-ui/lab";
+
+import { IBase } from "../../../../types/Base";
+import { getComposedDataCy, ISubpart } from "../../../../utils";
+
+interface ISelectGroup extends IBase, MUIAutocompleteRenderGroupParams {
+  dataCy: string;
+  getGroupLabel?: (groupName: string) => string;
+}
+
+export const SELECT_GROUP_SUBPART: ISubpart = {
+  label: "Option Group (with label)",
+  value: (label = "{label}") => `option-group-${label}`,
+};
+
+const SelectGroup: FC<ISelectGroup> = ({ dataCy: externalDataCy, getGroupLabel, ...props }) => {
+  const { children, group, key } = props;
+  const theme = useTheme();
+
+  const groupLabel = useMemo(() => (getGroupLabel ? getGroupLabel(group) : group), [getGroupLabel, group]);
+
+  const dataCy = useMemo(
+    () => getComposedDataCy(externalDataCy, SELECT_GROUP_SUBPART, groupLabel),
+    [externalDataCy, groupLabel]
+  );
+
+  const style = useMemo(() => ({ backgroundColor: theme.palette.background.default }), [theme]);
+
+  return (
+    <Fragment key={`group-${key}`}>
+      <MUIListSubheader data-cy={dataCy} style={style}>
+        {groupLabel}
+      </MUIListSubheader>
+      {children}
+    </Fragment>
+  );
+};
+
+export default SelectGroup;

--- a/src/components/Select/components/Group/index.tsx
+++ b/src/components/Select/components/Group/index.tsx
@@ -5,8 +5,8 @@ import { AutocompleteRenderGroupParams as MUIAutocompleteRenderGroupParams } fro
 import { IBase } from "../../../../types/Base";
 import { getComposedDataCy, ISubpart } from "../../../../utils";
 
-interface ISelectGroup extends IBase, MUIAutocompleteRenderGroupParams {
-  dataCy: string;
+interface ISelectGroup extends IBase {
+  forwarded: MUIAutocompleteRenderGroupParams;
   getGroupLabel?: (groupName: string) => string;
 }
 
@@ -15,22 +15,22 @@ export const SELECT_GROUP_SUBPART: ISubpart = {
   value: (label = "{label}") => `option-group-${label}`,
 };
 
-const SelectGroup: FC<ISelectGroup> = ({ dataCy: externalDataCy, getGroupLabel, ...props }) => {
-  const { children, group, key } = props;
+const SelectGroup: FC<ISelectGroup> = ({
+  dataCy = "select-group",
+  forwarded: { children, group, key },
+  getGroupLabel,
+}) => {
   const theme = useTheme();
 
   const groupLabel = useMemo(() => (getGroupLabel ? getGroupLabel(group) : group), [getGroupLabel, group]);
 
-  const dataCy = useMemo(
-    () => getComposedDataCy(externalDataCy, SELECT_GROUP_SUBPART, groupLabel),
-    [externalDataCy, groupLabel]
-  );
+  const groupDataCy = useMemo(() => getComposedDataCy(dataCy, SELECT_GROUP_SUBPART, groupLabel), [dataCy, groupLabel]);
 
   const style = useMemo(() => ({ backgroundColor: theme.palette.background.default }), [theme]);
 
   return (
     <Fragment key={`group-${key}`}>
-      <MUIListSubheader data-cy={dataCy} style={style}>
+      <MUIListSubheader data-cy={groupDataCy} style={style}>
         {groupLabel}
       </MUIListSubheader>
       {children}

--- a/src/components/Select/components/Input/index.tsx
+++ b/src/components/Select/components/Input/index.tsx
@@ -1,0 +1,78 @@
+import React, { CSSProperties, FC, useMemo } from "react";
+import { TextField as MUITextField } from "@material-ui/core";
+import {
+  AutocompleteRenderInputParams as MUIAutocompleteRenderInputParams,
+  Skeleton as MUISkeleton,
+} from "@material-ui/lab";
+
+import { ILoadable } from "../../../../types/Base";
+import { IInputField } from "../../../../types/Input";
+import { getComposedDataCy, ISubpart } from "../../../../utils";
+
+interface ISelectInput
+  extends Pick<IInputField, "dataCy" | "label" | "placeholder" | "required" | "size" | "type" | "variant">,
+    ILoadable {
+  forwarded: MUIAutocompleteRenderInputParams;
+}
+
+export const SELECT_LOADING_SUBPART: ISubpart = {
+  label: "Loading",
+};
+
+const SelectInput: FC<ISelectInput> = ({
+  dataCy = "select-input",
+  forwarded,
+  label,
+  loading,
+  placeholder,
+  required,
+  size,
+  style: externalStyle,
+  type,
+  variant,
+}) => {
+  const { inputProps: forwardedInputProps } = forwarded;
+
+  const style = useMemo((): CSSProperties => ({ ...externalStyle, width: "100%" }), [externalStyle]);
+
+  const inputDataCy = useMemo(
+    () => (!loading ? dataCy : getComposedDataCy(dataCy, SELECT_LOADING_SUBPART)),
+    [dataCy, loading]
+  );
+
+  const inputProps = useMemo(
+    () => ({
+      ...forwarded,
+      inputProps: {
+        ...forwardedInputProps,
+        "data-cy": inputDataCy,
+        style,
+      },
+    }),
+    [forwarded, forwardedInputProps, inputDataCy, style]
+  );
+
+  if (loading) {
+    return (
+      <MUISkeleton width="100%">
+        <MUITextField {...inputProps} margin="normal" size={size} variant={variant} style={style} />
+      </MUISkeleton>
+    );
+  }
+
+  return (
+    <MUITextField
+      {...inputProps}
+      label={label}
+      margin="normal"
+      placeholder={placeholder}
+      required={required}
+      size={size}
+      style={style}
+      type={type}
+      variant={variant}
+    />
+  );
+};
+
+export default SelectInput;

--- a/src/components/Select/components/Input/index.tsx
+++ b/src/components/Select/components/Input/index.tsx
@@ -9,9 +9,10 @@ import { ILoadable } from "../../../../types/Base";
 import { IInputField } from "../../../../types/Input";
 import { getComposedDataCy, ISubpart } from "../../../../utils";
 
-interface ISelectInput
-  extends Pick<IInputField, "dataCy" | "label" | "placeholder" | "required" | "size" | "type" | "variant">,
-    ILoadable {
+type ISelectInputField = Pick<IInputField, "dataCy" | "label" | "placeholder"> &
+  Required<Pick<IInputField, "required" | "size" | "type" | "variant">>;
+
+interface ISelectInput extends ISelectInputField, ILoadable {
   forwarded: MUIAutocompleteRenderInputParams;
 }
 

--- a/src/components/Select/components/Option/index.tsx
+++ b/src/components/Select/components/Option/index.tsx
@@ -7,6 +7,7 @@ import Typography from "../../../Typography";
 
 interface ISelectOption<T> extends IBase {
   getOptionLabel: (option: T) => string;
+  multiple: boolean;
   option: T;
   selected: boolean;
 }
@@ -24,6 +25,7 @@ export const SELECT_OPTION_LABEL_SUBPART: ISubpart = {
 const SelectOption = <T extends any>({
   dataCy = "select-option",
   getOptionLabel,
+  multiple,
   option,
   selected,
 }: ISelectOption<T>) => {
@@ -41,7 +43,7 @@ const SelectOption = <T extends any>({
 
   return (
     <Fragment key={`option-${optionLabel}`}>
-      <Checkbox dataCy={checkboxDataCy} disabled labelPlacement="end" value={selected} />
+      {multiple && <Checkbox dataCy={checkboxDataCy} disabled labelPlacement="end" value={selected} />}
       <Typography dataCy={labelDataCy}>{optionLabel}</Typography>
     </Fragment>
   );

--- a/src/components/Select/components/Option/index.tsx
+++ b/src/components/Select/components/Option/index.tsx
@@ -1,0 +1,50 @@
+import React, { Fragment, useMemo } from "react";
+
+import { IBase } from "../../../../types/Base";
+import { getComposedDataCy, ISubpart } from "../../../../utils";
+import Checkbox from "../../../Checkbox";
+import Typography from "../../../Typography";
+
+interface ISelectOption<T> extends IBase {
+  getOptionLabel: (option: T) => string;
+  option: T;
+  selected: boolean;
+}
+
+export const SELECT_OPTION_CHECKBOX_SUBPART: ISubpart = {
+  label: "Option Checkbox (with label)",
+  value: (label = "{label}") => `option-${label}-checkbox`,
+};
+
+export const SELECT_OPTION_LABEL_SUBPART: ISubpart = {
+  label: "Option Label (with label)",
+  value: (label = "{label}") => `option-${label}-label`,
+};
+
+const SelectOption = <T extends any>({
+  dataCy = "select-option",
+  getOptionLabel,
+  option,
+  selected,
+}: ISelectOption<T>) => {
+  const optionLabel = useMemo(() => getOptionLabel(option), [getOptionLabel, option]);
+
+  const checkboxDataCy = useMemo(
+    () => getComposedDataCy(dataCy, SELECT_OPTION_CHECKBOX_SUBPART, optionLabel),
+    [dataCy, optionLabel]
+  );
+
+  const labelDataCy = useMemo(
+    () => getComposedDataCy(dataCy, SELECT_OPTION_LABEL_SUBPART, optionLabel),
+    [dataCy, optionLabel]
+  );
+
+  return (
+    <Fragment key={`option-${optionLabel}`}>
+      <Checkbox dataCy={checkboxDataCy} disabled labelPlacement="end" value={selected} />
+      <Typography dataCy={labelDataCy}>{optionLabel}</Typography>
+    </Fragment>
+  );
+};
+
+export default SelectOption;

--- a/src/components/Select/components/Option/index.tsx
+++ b/src/components/Select/components/Option/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useMemo } from "react";
+import React, { Fragment, ReactNode, useMemo } from "react";
 
 import { IBase } from "../../../../types/Base";
 import { getComposedDataCy, ISubpart } from "../../../../utils";
@@ -6,11 +6,17 @@ import Checkbox from "../../../Checkbox";
 import Typography from "../../../Typography";
 
 interface ISelectOption<T> extends IBase {
+  customRenderer?: (option: T, selected: boolean) => ReactNode;
   getOptionLabel: (option: T) => string;
   multiple: boolean;
   option: T;
   selected: boolean;
 }
+
+export const SELECT_OPTION_SUBPART: ISubpart = {
+  label: "Option (with label)",
+  value: (label = "{label}") => `option-${label}`,
+};
 
 export const SELECT_OPTION_CHECKBOX_SUBPART: ISubpart = {
   label: "Option Checkbox (with label)",
@@ -23,6 +29,7 @@ export const SELECT_OPTION_LABEL_SUBPART: ISubpart = {
 };
 
 const SelectOption = <T extends any>({
+  customRenderer,
   dataCy = "select-option",
   getOptionLabel,
   multiple,
@@ -41,11 +48,33 @@ const SelectOption = <T extends any>({
     [dataCy, optionLabel]
   );
 
+  const optionDataCy = useMemo(
+    () => getComposedDataCy(dataCy, SELECT_OPTION_SUBPART, optionLabel),
+    [dataCy, optionLabel]
+  );
+
+  const customContent = useMemo(
+    () => (customRenderer ? customRenderer(option, selected) : undefined),
+    [customRenderer, option, selected]
+  );
+
+  const content = useMemo(() => {
+    if (customContent) {
+      return customContent;
+    }
+
+    return (
+      <Fragment>
+        {multiple && <Checkbox dataCy={checkboxDataCy} disabled labelPlacement="end" value={selected} />}
+        <Typography dataCy={labelDataCy}>{optionLabel}</Typography>
+      </Fragment>
+    );
+  }, [checkboxDataCy, customContent, labelDataCy, optionLabel, multiple, selected]);
+
   return (
-    <Fragment key={`option-${optionLabel}`}>
-      {multiple && <Checkbox dataCy={checkboxDataCy} disabled labelPlacement="end" value={selected} />}
-      <Typography dataCy={labelDataCy}>{optionLabel}</Typography>
-    </Fragment>
+    <div key={optionDataCy} data-cy={optionDataCy} style={{ display: "contents" }}>
+      {content}
+    </div>
   );
 };
 

--- a/src/components/Select/components/Popper/index.tsx
+++ b/src/components/Select/components/Popper/index.tsx
@@ -1,12 +1,13 @@
 import React, { FC, useMemo } from "react";
 import { Popper as MUIPopper, PopperProps as MUIPopperProps } from "@material-ui/core";
 
-interface ISelectPopper extends MUIPopperProps {
+interface ISelectPopper {
+  forwarded: MUIPopperProps;
   popperWidth: any;
 }
 
-const SelectPopper: FC<ISelectPopper> = ({ popperWidth, ...props }) => {
-  const { anchorEl } = props;
+const SelectPopper: FC<ISelectPopper> = ({ forwarded, popperWidth }) => {
+  const { anchorEl } = forwarded;
 
   const width = useMemo(() => {
     const anchorElRef = anchorEl as any;
@@ -14,7 +15,7 @@ const SelectPopper: FC<ISelectPopper> = ({ popperWidth, ...props }) => {
     return !!popperWidth && popperWidth > anchorElWidth ? popperWidth : anchorElWidth;
   }, [popperWidth, anchorEl]);
 
-  return <MUIPopper {...props} placement="bottom-start" style={{ width }} />;
+  return <MUIPopper {...forwarded} placement="bottom-start" style={{ width }} />;
 };
 
 export default SelectPopper;

--- a/src/components/Select/components/Popper/index.tsx
+++ b/src/components/Select/components/Popper/index.tsx
@@ -1,0 +1,20 @@
+import React, { FC, useMemo } from "react";
+import { Popper as MUIPopper, PopperProps as MUIPopperProps } from "@material-ui/core";
+
+interface ISelectPopper extends MUIPopperProps {
+  popperWidth: any;
+}
+
+const SelectPopper: FC<ISelectPopper> = ({ popperWidth, ...props }) => {
+  const { anchorEl } = props;
+
+  const width = useMemo(() => {
+    const anchorElRef = anchorEl as any;
+    const anchorElWidth = anchorElRef ? anchorElRef.clientWidth : null;
+    return !!popperWidth && popperWidth > anchorElWidth ? popperWidth : anchorElWidth;
+  }, [popperWidth, anchorEl]);
+
+  return <MUIPopper {...props} placement="bottom-start" style={{ width }} />;
+};
+
+export default SelectPopper;

--- a/src/components/Select/index.test.tsx
+++ b/src/components/Select/index.test.tsx
@@ -1,9 +1,12 @@
 // TODO: temp commenting out snapshots due to id="mui-XXXXX" property
 // import renderer from "react-test-renderer";
 
+import React from "react";
+
 import { ISelect } from "../../types/Select";
 import { getComposedDataCy } from "../../utils";
 import { getTestableComponent, IPartialTestOptions, ITestOptions } from "../../utils/tests";
+import Typography from "../Typography";
 
 import Select, { DATA_CY_DEFAULT, SUBPARTS_MAP } from ".";
 
@@ -44,7 +47,7 @@ describe("Select Single test suite:", () => {
     expect(wrapper.prop("disabled")).toBeTruthy();
   });
 
-  it("groupBy - default", () => {
+  it("groupBy", () => {
     const outerWrapperDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.outerWrapper);
     const { wrapper } = getSelectTestable({
       dataCy: outerWrapperDataCy,
@@ -85,6 +88,27 @@ describe("Select Single test suite:", () => {
     expect(optionsLabels).toEqual(["Mosaic", "Murales", "Paintings", "Photography", "Sculpture"]);
   });
 
+  it("groupBy - getGroupLabel", () => {
+    const outerWrapperDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.outerWrapper);
+    const { wrapper } = getSelectTestable({
+      dataCy: outerWrapperDataCy,
+      domNode: "div",
+      mountOnly: true,
+      props: {
+        getGroupLabel: (group) => `${group.slice(0, 1).toUpperCase()}*`,
+        groupBy: (option) => option.slice(0, 1),
+      },
+    });
+
+    const input = wrapper.find(`input[data-cy='${DATA_CY_DEFAULT}']`);
+    input.simulate("mousedown");
+
+    const eachGroupDataCy = `${DATA_CY_DEFAULT}-option-group-`;
+    const groups = wrapper.find(`li[data-cy^='${eachGroupDataCy}']`);
+    const groupsLabels = groups.map((group) => group.text());
+    expect(groupsLabels).toEqual(["M*", "P*", "S*"]);
+  });
+
   it("immutable options", () => {
     const frozenOptions = Object.freeze(["Photography", "Sculpture", "Mosaic", "Murales", "Paintings"]) as string[];
     getSelectTestable({ props: { options: frozenOptions } });
@@ -97,7 +121,7 @@ describe("Select Single test suite:", () => {
     expect(placeholder).toHaveLength(1);
   });
 
-  it("onChange - single", () => {
+  it("onChange", () => {
     const onChangeCallback = jest.fn();
     const outerWrapperDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.outerWrapper);
     const { wrapper } = getSelectTestable({
@@ -190,7 +214,7 @@ describe("Select Single test suite:", () => {
     expect(onScrollEndCallback).toHaveBeenCalledTimes(1);
   });
 
-  it("options - default", () => {
+  it("options", () => {
     const outerWrapperDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.outerWrapper);
     const { wrapper } = getSelectTestable({
       dataCy: outerWrapperDataCy,
@@ -225,10 +249,62 @@ describe("Select Single test suite:", () => {
     expect(optionsLabels).toEqual(DEFAULT_TEST_OPTIONS.props.options.reverse());
   });
 
+  it("options - custom rendering", () => {
+    const outerWrapperDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.outerWrapper);
+    const { wrapper } = getSelectTestable({
+      dataCy: outerWrapperDataCy,
+      domNode: "div",
+      mountOnly: true,
+      props: {
+        customOptionRendering: (option: string, selected: boolean) => <Typography>{option.slice(0, 1)}</Typography>,
+      },
+    });
+
+    const input = wrapper.find(`input[data-cy='${DATA_CY_DEFAULT}']`);
+    input.simulate("mousedown");
+
+    const eachOptionDataCy = `${DATA_CY_DEFAULT}-option`;
+    const options = wrapper.find(`[data-cy^='${eachOptionDataCy}']`);
+    const optionsLabels = options.map((option) => option.text());
+    expect(optionsLabels).toEqual(["M", "M", "P", "P", "S"]);
+  });
+
   it("placeholder", () => {
     const placeholder = "Placeholder";
     const { wrapper } = getSelectTestable({ props: { placeholder } });
     expect(wrapper.prop("placeholder")).toEqual(placeholder);
+  });
+
+  it("popperWidth", () => {
+    const outerWrapperDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.outerWrapper);
+    const { wrapper } = getSelectTestable({
+      dataCy: outerWrapperDataCy,
+      domNode: "div",
+      mountOnly: true,
+    });
+
+    const input = wrapper.find(`input[data-cy='${DATA_CY_DEFAULT}']`);
+    input.simulate("mousedown");
+
+    const popper = wrapper.find("div.MuiAutocomplete-popper");
+    expect(popper.prop("style")).toMatchObject({ width: 0 });
+  });
+
+  it("popperWidth - custom and larger", () => {
+    const popperWidth = 800;
+    const outerWrapperDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.outerWrapper);
+    const { wrapper } = getSelectTestable({
+      dataCy: outerWrapperDataCy,
+      domNode: "div",
+      mountOnly: true,
+      props: { popperWidth },
+    });
+
+    const input = wrapper.find(`input[data-cy='${DATA_CY_DEFAULT}']`);
+    input.simulate("mousedown");
+
+    const popper = wrapper.find("div.MuiAutocomplete-popper");
+    expect(popper.prop("style")).toMatchObject({ width: popperWidth });
   });
 
   it("required", () => {

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -167,9 +167,10 @@ const Select = <T extends any>({
   );
 
   const renderGroup = useCallback(
-    (props: MUIAutocompleteRenderGroupParams) => (
-      <SelectGroup {...props} dataCy={dataCy} getGroupLabel={getGroupLabel} />
-    ),
+    (props: MUIAutocompleteRenderGroupParams) => {
+      const { key } = props;
+      return <SelectGroup key={key} dataCy={dataCy} forwarded={props} getGroupLabel={getGroupLabel} />;
+    },
     [dataCy, getGroupLabel]
   );
 
@@ -203,7 +204,7 @@ const Select = <T extends any>({
   );
 
   const renderPopper = useCallback(
-    (props: MUIPopperProps) => <SelectPopper {...props} popperWidth={popperWidth} />,
+    (props: MUIPopperProps) => <SelectPopper forwarded={props} popperWidth={popperWidth} />,
     [popperWidth]
   );
 

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -13,7 +13,11 @@ import localized, { ILocalizableProperty } from "../../utils/hocs/localized";
 
 import SelectGroup, { SELECT_GROUP_SUBPART } from "./components/Group";
 import SelectInput, { SELECT_LOADING_SUBPART } from "./components/Input";
-import SelectOption, { SELECT_OPTION_CHECKBOX_SUBPART, SELECT_OPTION_LABEL_SUBPART } from "./components/Option";
+import SelectOption, {
+  SELECT_OPTION_CHECKBOX_SUBPART,
+  SELECT_OPTION_LABEL_SUBPART,
+  SELECT_OPTION_SUBPART,
+} from "./components/Option";
 import SelectPopper from "./components/Popper";
 
 export const DATA_CY_DEFAULT = "select";
@@ -25,6 +29,7 @@ export const LOCALIZABLE_PROPS: ILocalizableProperty[] = [
 
 export const SUBPARTS_MAP = {
   loading: SELECT_LOADING_SUBPART,
+  option: SELECT_OPTION_SUBPART,
   optionCheckbox: SELECT_OPTION_CHECKBOX_SUBPART,
   optionLabel: SELECT_OPTION_LABEL_SUBPART,
   optionGroupLabel: SELECT_GROUP_SUBPART,
@@ -192,14 +197,16 @@ const Select = <T extends any>({
     [dataCy, label, loading, placeholder, required, size, style, type, variant]
   );
 
+  const renderCustomOption = useCallback(
+    (option: T, selected: boolean) => (customOptionRendering ? customOptionRendering(option, selected) : undefined),
+    [customOptionRendering]
+  );
+
   const renderOption = useCallback(
     (option: T, { selected }: MUIAutocompleteRenderOptionState) => {
-      if (customOptionRendering) {
-        return customOptionRendering(option, selected);
-      }
-
       return (
         <SelectOption
+          customRenderer={renderCustomOption}
           dataCy={dataCy}
           getOptionLabel={getOptionLabel}
           multiple={multiple}
@@ -208,7 +215,7 @@ const Select = <T extends any>({
         />
       );
     },
-    [dataCy, customOptionRendering, getOptionLabel, multiple]
+    [dataCy, getOptionLabel, multiple, renderCustomOption]
   );
 
   const renderPopper = useCallback(

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -198,9 +198,17 @@ const Select = <T extends any>({
         return customOptionRendering(option, selected);
       }
 
-      return <SelectOption dataCy={dataCy} getOptionLabel={getOptionLabel} option={option} selected={selected} />;
+      return (
+        <SelectOption
+          dataCy={dataCy}
+          getOptionLabel={getOptionLabel}
+          multiple={multiple}
+          option={option}
+          selected={selected}
+        />
+      );
     },
-    [dataCy, customOptionRendering, getOptionLabel]
+    [dataCy, customOptionRendering, getOptionLabel, multiple]
   );
 
   const renderPopper = useCallback(

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -1,19 +1,19 @@
-import React, { Fragment, SyntheticEvent, useCallback, useMemo } from "react";
+import React, { SyntheticEvent, useCallback, useMemo } from "react";
 import { PopperProps as MUIPopperProps } from "@material-ui/core";
 import {
   Autocomplete as MUIAutocomplete,
   AutocompleteRenderGroupParams as MUIAutocompleteRenderGroupParams,
   AutocompleteRenderInputParams as MUIAutocompleteRenderInputParams,
+  AutocompleteRenderOptionState as MUIAutocompleteRenderOptionState,
 } from "@material-ui/lab";
 
 import { ISelect } from "../../types/Select";
 import { getComposedDataCy, suppressEvent } from "../../utils";
 import localized, { ILocalizableProperty } from "../../utils/hocs/localized";
-import Checkbox from "../Checkbox";
-import Typography from "../Typography";
 
 import SelectGroup, { SELECT_GROUP_SUBPART } from "./components/Group";
 import SelectInput, { SELECT_LOADING_SUBPART } from "./components/Input";
+import SelectOption, { SELECT_OPTION_CHECKBOX_SUBPART, SELECT_OPTION_LABEL_SUBPART } from "./components/Option";
 import SelectPopper from "./components/Popper";
 
 export const DATA_CY_DEFAULT = "select";
@@ -25,14 +25,8 @@ export const LOCALIZABLE_PROPS: ILocalizableProperty[] = [
 
 export const SUBPARTS_MAP = {
   loading: SELECT_LOADING_SUBPART,
-  optionCheckbox: {
-    label: "Option Checkbox (with label)",
-    value: (label = "{label}") => `option-${label}-checkbox`,
-  },
-  optionLabel: {
-    label: "Option Label (with label)",
-    value: (label = "{label}") => `option-${label}-label`,
-  },
+  optionCheckbox: SELECT_OPTION_CHECKBOX_SUBPART,
+  optionLabel: SELECT_OPTION_LABEL_SUBPART,
   optionGroupLabel: SELECT_GROUP_SUBPART,
   outerWrapper: {
     label: "Outer Wrapper",
@@ -197,6 +191,17 @@ const Select = <T extends any>({
     [dataCy, label, loading, placeholder, required, size, style, type, variant]
   );
 
+  const renderOption = useCallback(
+    (option: T, { selected }: MUIAutocompleteRenderOptionState) => {
+      if (customOptionRendering) {
+        return customOptionRendering(option, selected);
+      }
+
+      return <SelectOption dataCy={dataCy} getOptionLabel={getOptionLabel} option={option} selected={selected} />;
+    },
+    [dataCy, customOptionRendering, getOptionLabel]
+  );
+
   const renderPopper = useCallback(
     (props: MUIPopperProps) => <SelectPopper {...props} popperWidth={popperWidth} />,
     [popperWidth]
@@ -236,27 +241,7 @@ const Select = <T extends any>({
       PopperComponent={renderPopper}
       renderGroup={renderGroup}
       renderInput={renderInput}
-      renderOption={(option, { selected }) => {
-        if (customOptionRendering) {
-          return customOptionRendering(option, selected);
-        }
-
-        const optionLabel = getOptionLabel(option);
-
-        return (
-          <Fragment key={`option-${optionLabel}`}>
-            <Checkbox
-              dataCy={getComposedDataCy(dataCy, SUBPARTS_MAP.optionCheckbox, optionLabel)}
-              disabled
-              labelPlacement="end"
-              value={selected}
-            />
-            <Typography dataCy={getComposedDataCy(dataCy, SUBPARTS_MAP.optionLabel, optionLabel)}>
-              {optionLabel}
-            </Typography>
-          </Fragment>
-        );
-      }}
+      renderOption={renderOption}
       value={validatedValue}
     />
   );


### PR DESCRIPTION
[refactor: 💡 [Select] Split Group and Popper components]
refactor: 💡 [Select] Split Input component 
refactor: 💡 [Select] Split Option component 
refactor: 💡 [Select] Code cleaning for inner components 
feat: 🎸 [Select] Display checkbox only when multiple=true
feat: 🎸 [Select] Wrapped each option in a div with dataCy 
[test: 💍 [Select] Updated tests]

Closes #249 