### PR TITLE
Add Badge and Tooltip features to components

### DIFF
--- a/src/components/Adornment/components/Badge/index.tsx
+++ b/src/components/Adornment/components/Badge/index.tsx
@@ -1,10 +1,10 @@
 import React, { FC, Fragment, useMemo } from "react";
 import { Badge as MUIBadge } from "@material-ui/core";
 
-import { IAdornment } from "../../../../types/Adornment";
+import { IAdornment, IAdornmentBadgeSubpart } from "../../../../types/Adornment";
 import { getComposedDataCy, ISubpartMap } from "../../../../utils";
 
-export const ADORNMENT_BADGE_SUBPARTS: ISubpartMap = {
+export const ADORNMENT_BADGE_SUBPARTS: ISubpartMap<IAdornmentBadgeSubpart> = {
   badge: {
     label: "Badge",
   },
@@ -12,7 +12,7 @@ export const ADORNMENT_BADGE_SUBPARTS: ISubpartMap = {
 
 const DEFAULT_DATA_CY = "adornment-badge";
 
-const Badge: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA_CY }) => {
+const AdornmentBadge: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA_CY }) => {
   const badgeDataCy = useMemo(() => getComposedDataCy(dataCy, ADORNMENT_BADGE_SUBPARTS.badge), [dataCy]);
 
   if (!badge) {
@@ -28,4 +28,4 @@ const Badge: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA_CY }) =>
   );
 };
 
-export default Badge;
+export default AdornmentBadge;

--- a/src/components/Adornment/components/Badge/index.tsx
+++ b/src/components/Adornment/components/Badge/index.tsx
@@ -1,0 +1,31 @@
+import React, { FC, Fragment, useMemo } from "react";
+import { Badge as MUIBadge } from "@material-ui/core";
+
+import { IAdornment } from "../../../../types/Adornment";
+import { getComposedDataCy, ISubpartMap } from "../../../../utils";
+
+export const ADORNMENT_BADGE_SUBPARTS: ISubpartMap = {
+  badge: {
+    label: "Badge",
+  },
+};
+
+const DEFAULT_DATA_CY = "adornment-badge";
+
+const Badge: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA_CY }) => {
+  const badgeDataCy = useMemo(() => getComposedDataCy(dataCy, ADORNMENT_BADGE_SUBPARTS.badge), [dataCy]);
+
+  if (!badge) {
+    return <Fragment>{children}</Fragment>;
+  }
+
+  const { color = "default", value, variant = "standard" } = badge;
+
+  return (
+    <MUIBadge badgeContent={value} color={color} data-cy={badgeDataCy} variant={variant}>
+      {children}
+    </MUIBadge>
+  );
+};
+
+export default Badge;

--- a/src/components/Adornment/components/Badge/index.tsx
+++ b/src/components/Adornment/components/Badge/index.tsx
@@ -22,7 +22,7 @@ const AdornmentBadge: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA
   const { color = "default", value, variant = "standard" } = badge;
 
   return (
-    <MUIBadge badgeContent={value} color={color} data-cy={badgeDataCy} variant={variant}>
+    <MUIBadge badgeContent={value} color={color} data-cy={badgeDataCy} overlap="circular" variant={variant}>
       {children}
     </MUIBadge>
   );

--- a/src/components/Adornment/components/Badge/index.tsx
+++ b/src/components/Adornment/components/Badge/index.tsx
@@ -19,10 +19,10 @@ const AdornmentBadge: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA
     return <Fragment>{children}</Fragment>;
   }
 
-  const { color = "default", value, variant = "standard" } = badge;
+  const { color = "default", overlap = "circular", value, variant = "standard" } = badge;
 
   return (
-    <MUIBadge badgeContent={value} color={color} data-cy={badgeDataCy} overlap="circular" variant={variant}>
+    <MUIBadge badgeContent={value} color={color} data-cy={badgeDataCy} overlap={overlap} variant={variant}>
       {children}
     </MUIBadge>
   );

--- a/src/components/Adornment/components/Tooltip/index.tsx
+++ b/src/components/Adornment/components/Tooltip/index.tsx
@@ -1,10 +1,10 @@
 import React, { FC, Fragment, useMemo } from "react";
 import { Tooltip as MUITooltip } from "@material-ui/core";
 
-import { IAdornment } from "../../../../types/Adornment";
+import { IAdornment, IAdornmentTooltipSubpart } from "../../../../types/Adornment";
 import { getComposedDataCy, ISubpartMap, slugify } from "../../../../utils";
 
-export const ADORNMENT_TOOLTIP_SUBPARTS: ISubpartMap = {
+export const ADORNMENT_TOOLTIP_SUBPARTS: ISubpartMap<IAdornmentTooltipSubpart> = {
   tooltip: {
     label: "Tooltip",
   },
@@ -12,7 +12,7 @@ export const ADORNMENT_TOOLTIP_SUBPARTS: ISubpartMap = {
 
 const DEFAULT_DATA_CY = "adornment-tooltip";
 
-const Tooltip: FC<IAdornment> = ({ children, dataCy = DEFAULT_DATA_CY, tooltip }) => {
+const AdornmentTooltip: FC<IAdornment> = ({ children, dataCy = DEFAULT_DATA_CY, tooltip }) => {
   const tooltipDataCy = useMemo(() => getComposedDataCy(dataCy, ADORNMENT_TOOLTIP_SUBPARTS.tooltip), [dataCy]);
 
   if (!tooltip) {
@@ -26,4 +26,4 @@ const Tooltip: FC<IAdornment> = ({ children, dataCy = DEFAULT_DATA_CY, tooltip }
   );
 };
 
-export default Tooltip;
+export default AdornmentTooltip;

--- a/src/components/Adornment/components/Tooltip/index.tsx
+++ b/src/components/Adornment/components/Tooltip/index.tsx
@@ -1,0 +1,29 @@
+import React, { FC, Fragment, useMemo } from "react";
+import { Tooltip as MUITooltip } from "@material-ui/core";
+
+import { IAdornment } from "../../../../types/Adornment";
+import { getComposedDataCy, ISubpartMap, slugify } from "../../../../utils";
+
+export const ADORNMENT_TOOLTIP_SUBPARTS: ISubpartMap = {
+  tooltip: {
+    label: "Tooltip",
+  },
+};
+
+const DEFAULT_DATA_CY = "adornment-tooltip";
+
+const Tooltip: FC<IAdornment> = ({ children, dataCy = DEFAULT_DATA_CY, tooltip }) => {
+  const tooltipDataCy = useMemo(() => getComposedDataCy(dataCy, ADORNMENT_TOOLTIP_SUBPARTS.tooltip), [dataCy]);
+
+  if (!tooltip) {
+    return <Fragment>{children}</Fragment>;
+  }
+
+  return (
+    <MUITooltip aria-label={slugify(tooltip)} data-cy={tooltipDataCy} title={tooltip}>
+      <span>{children}</span>
+    </MUITooltip>
+  );
+};
+
+export default Tooltip;

--- a/src/components/Adornment/index.tsx
+++ b/src/components/Adornment/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, Fragment } from "react";
 
 import { IAdornment, IAdornmentSubpart } from "../../types/Adornment";
 import { ISubpartMap } from "../../utils";
@@ -17,6 +17,10 @@ export const ADORNMENT_SUBPARTS: ISubpartMap<IAdornmentSubpart> = {
 const DEFAULT_DATA_CY = "adornment";
 
 const Adornment: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA_CY, tooltip }) => {
+  if (!badge && !tooltip) {
+    return <Fragment>{children}</Fragment>;
+  }
+
   return (
     <span data-cy={dataCy}>
       <AdornmentTooltip dataCy={dataCy} tooltip={tooltip}>

--- a/src/components/Adornment/index.tsx
+++ b/src/components/Adornment/index.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from "react";
+
+import { IAdornment } from "../../types/Adornment";
+import { ISubpartMap } from "../../utils";
+
+import Badge, { ADORNMENT_BADGE_SUBPARTS } from "./components/Badge";
+import Tooltip, { ADORNMENT_TOOLTIP_SUBPARTS } from "./components/Tooltip";
+
+export const ADORNMENT_SUBPARTS: ISubpartMap = {
+  ...ADORNMENT_BADGE_SUBPARTS,
+  ...ADORNMENT_TOOLTIP_SUBPARTS,
+  adornment: {
+    label: "Adornment",
+  },
+};
+
+const DEFAULT_DATA_CY = "adornment";
+
+const Adornment: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA_CY, tooltip }) => {
+  return (
+    <span data-cy={dataCy}>
+      <Tooltip dataCy={dataCy} tooltip={tooltip}>
+        <Badge badge={badge} dataCy={dataCy}>
+          {children}
+        </Badge>
+      </Tooltip>
+    </span>
+  );
+};
+
+export default Adornment;

--- a/src/components/Adornment/index.tsx
+++ b/src/components/Adornment/index.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from "react";
 
-import { IAdornment } from "../../types/Adornment";
+import { IAdornment, IAdornmentSubpart } from "../../types/Adornment";
 import { ISubpartMap } from "../../utils";
 
-import Badge, { ADORNMENT_BADGE_SUBPARTS } from "./components/Badge";
-import Tooltip, { ADORNMENT_TOOLTIP_SUBPARTS } from "./components/Tooltip";
+import AdornmentBadge, { ADORNMENT_BADGE_SUBPARTS } from "./components/Badge";
+import AdornmentTooltip, { ADORNMENT_TOOLTIP_SUBPARTS } from "./components/Tooltip";
 
-export const ADORNMENT_SUBPARTS: ISubpartMap = {
+export const ADORNMENT_SUBPARTS: ISubpartMap<IAdornmentSubpart> = {
   ...ADORNMENT_BADGE_SUBPARTS,
   ...ADORNMENT_TOOLTIP_SUBPARTS,
   adornment: {
@@ -19,11 +19,11 @@ const DEFAULT_DATA_CY = "adornment";
 const Adornment: FC<IAdornment> = ({ badge, children, dataCy = DEFAULT_DATA_CY, tooltip }) => {
   return (
     <span data-cy={dataCy}>
-      <Tooltip dataCy={dataCy} tooltip={tooltip}>
-        <Badge badge={badge} dataCy={dataCy}>
+      <AdornmentTooltip dataCy={dataCy} tooltip={tooltip}>
+        <AdornmentBadge badge={badge} dataCy={dataCy}>
           {children}
-        </Badge>
-      </Tooltip>
+        </AdornmentBadge>
+      </AdornmentTooltip>
     </span>
   );
 };

--- a/src/components/AppBar/components/Actions/index.tsx
+++ b/src/components/AppBar/components/Actions/index.tsx
@@ -49,13 +49,15 @@ const AppBarActions: FC<IAppBarActions> = ({ actions, dataCy = DATA_CY_DEFAULT, 
       return null;
     }
 
-    return actions.map(({ icon, onClick, style }, index) => (
+    return actions.map(({ badge, icon, onClick, style, tooltip }, index) => (
       <IconButton
         key={`action-${index}`}
+        badge={badge}
         dataCy={getComposedDataCy(dataCy, APPBAR_ACTIONS_SUBPARTS.action, index)}
         icon={icon}
         onClick={onClick}
         style={{ marginRight: `${theme.spacing(0.5)}px`, ...style }}
+        tooltip={tooltip}
       />
     ));
   }, [actions, dataCy, theme]);

--- a/src/components/AppBar/components/Content/index.tsx
+++ b/src/components/AppBar/components/Content/index.tsx
@@ -22,8 +22,8 @@ const AppBarContent: FC<IAppBarContent> = ({ children, dataCy = DATA_CY_DEFAULT,
       return null;
     }
 
-    const { icon, onClick } = menu;
-    return <IconButton dataCy={mainMenuDataCy} icon={icon} onClick={onClick} />;
+    const { badge, icon, onClick, tooltip } = menu;
+    return <IconButton badge={badge} dataCy={mainMenuDataCy} icon={icon} onClick={onClick} tooltip={tooltip} />;
   }, [mainMenuDataCy, menu]);
 
   const style = useMemo(

--- a/src/components/AppBar/index.stories.tsx
+++ b/src/components/AppBar/index.stories.tsx
@@ -45,11 +45,13 @@ Primary.args = {
     {
       icon: Icons.settings,
       onClick: () => {},
+      tooltip: "Settings",
     },
   ],
   menu: {
     icon: Icons.home,
     onClick: () => {},
+    tooltip: "Home",
   },
   title: "AppBar",
 };
@@ -59,16 +61,23 @@ Actions.args = {
   ...Primary.args,
   actions: [
     {
+      badge: {
+        color: "error",
+        value: "5",
+      },
       icon: Icons.notifications,
       onClick: () => {},
+      tooltip: "Notifications",
     },
     {
       icon: Icons.mail,
       onClick: () => {},
+      tooltip: "Mail",
     },
     {
       icon: Icons.settings,
       onClick: () => {},
+      tooltip: "Settings",
     },
   ],
 };

--- a/src/components/AppBar/index.test.tsx
+++ b/src/components/AppBar/index.test.tsx
@@ -152,7 +152,7 @@ describe("AppBar test suite:", () => {
   it("userMenu", () => {
     const onClick = jest.fn();
     const { wrapper } = getAppBarTestable({
-      props: { user: { items: [{ label: "Logout", onClick, value: "logout" }] } },
+      props: { user: { items: [{ label: "Logout", onClick, value: "logout" }], label: "User" } },
     });
 
     const userMenuButtonDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.userMenu);
@@ -183,7 +183,7 @@ describe("AppBar test suite:", () => {
 
   it("username", () => {
     const onClick = jest.fn();
-    const username = "mos@ic";
+    const username: string = "mos@ic";
     const { wrapper } = getAppBarTestable({
       props: { user: { items: [{ label: "Logout", onClick, value: "logout" }], label: username } },
     });

--- a/src/components/AppBar/index.tsx
+++ b/src/components/AppBar/index.tsx
@@ -65,7 +65,7 @@ const AppBar: FC<IAppBar> = ({
     const userMenuItems = userMenu.map((menuItem) => ({ ...menuItem, value: menuItem.label }));
     return {
       items: userMenuItems,
-      label: username,
+      label: username || "User",
     };
   }, [user, userMenu, username]);
 

--- a/src/components/Icon/index.stories.tsx
+++ b/src/components/Icon/index.stories.tsx
@@ -33,6 +33,16 @@ Primary.args = {
   name: Icons.account,
 };
 
+export const Badge = Template.bind({});
+Badge.args = {
+  ...Primary.args,
+  badge: {
+    color: "secondary",
+    overlap: "rectangular",
+    value: "5",
+  },
+};
+
 export const IconCustom = Template.bind({});
 IconCustom.args = {
   children: <MUIStyleIcon />,
@@ -71,6 +81,12 @@ Styled.args = {
     color: "white",
     padding: "4px",
   },
+};
+
+export const Tooltip = Template.bind({});
+Tooltip.args = {
+  ...Primary.args,
+  tooltip: "Account",
 };
 
 // TODO: add this story using union type

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -4,6 +4,7 @@ import { Skeleton as MUISkeleton } from "@material-ui/lab";
 
 import { IIcon, IIconDimensions, IRenderedIcon } from "../../types/Icon";
 import { logWarn } from "../../utils/logger";
+import Adornment from "../Adornment";
 
 import { iconsCatalog } from "./utils";
 
@@ -30,6 +31,7 @@ const useAnimations = makeStyles({
 });
 
 const Icon: FC<IIcon> = ({
+  badge,
   children,
   dataCy = DATA_CY_DEFAULT,
   forwarded = {},
@@ -38,6 +40,7 @@ const Icon: FC<IIcon> = ({
   rotate = false,
   size = "medium",
   style: externalStyle,
+  tooltip,
 }) => {
   const { rotate: rotateAnimation } = useAnimations();
 
@@ -73,7 +76,11 @@ const Icon: FC<IIcon> = ({
   }
 
   if (children) {
-    return cloneElement(children as ReactElement<any>, { ...props });
+    return (
+      <Adornment badge={badge} tooltip={tooltip}>
+        {cloneElement(children as ReactElement<any>, { ...props })}
+      </Adornment>
+    );
   }
 
   if (!name) {
@@ -82,7 +89,12 @@ const Icon: FC<IIcon> = ({
   }
 
   const icon = iconsCatalog[name];
-  return cloneElement(icon, { ...props });
+
+  return (
+    <Adornment badge={badge} tooltip={tooltip}>
+      {cloneElement(icon, { ...props })}
+    </Adornment>
+  );
 };
 
 export default Icon;

--- a/src/components/IconButton/__snapshots__/index.test.tsx.snap
+++ b/src/components/IconButton/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,185 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`IconButton test suite: adornment - badge & tooltip 1`] = `
+<span
+  data-cy="icon-button-adornment"
+>
+  <span
+    aria-describedby={null}
+    aria-label="account"
+    className=""
+    data-cy="icon-button-adornment-tooltip"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    title="Account"
+  >
+    <span
+      className="MuiBadge-root"
+      data-cy="icon-button-adornment-badge"
+    >
+      <button
+        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+        data-cy="icon-button"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        <span
+          className="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden={true}
+            className="MuiSvgIcon-root"
+            data-cy="icon-button-icon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+            />
+          </svg>
+        </span>
+        <span
+          className="MuiTouchRipple-root"
+        />
+      </button>
+      <span
+        className="MuiBadge-badge MuiBadge-anchorOriginTopRightRectangle"
+      >
+        3
+      </span>
+    </span>
+  </span>
+</span>
+`;
+
+exports[`IconButton test suite: adornment - badge 1`] = `
+<span
+  data-cy="icon-button-adornment"
+>
+  <span
+    className="MuiBadge-root"
+    data-cy="icon-button-adornment-badge"
+  >
+    <button
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+      data-cy="icon-button"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className="MuiIconButton-label"
+      >
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root"
+          data-cy="icon-button-icon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+          />
+        </svg>
+      </span>
+    </button>
+    <span
+      className="MuiBadge-badge MuiBadge-anchorOriginTopRightRectangle"
+    >
+      3
+    </span>
+  </span>
+</span>
+`;
+
+exports[`IconButton test suite: adornment - tooltip 1`] = `
+<span
+  data-cy="icon-button-adornment"
+>
+  <span
+    aria-describedby={null}
+    aria-label="account"
+    className=""
+    data-cy="icon-button-adornment-tooltip"
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onMouseLeave={[Function]}
+    onMouseOver={[Function]}
+    onTouchEnd={[Function]}
+    onTouchStart={[Function]}
+    title="Account"
+  >
+    <button
+      className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+      data-cy="icon-button"
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onDragLeave={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
+      tabIndex={0}
+      type="button"
+    >
+      <span
+        className="MuiIconButton-label"
+      >
+        <svg
+          aria-hidden={true}
+          className="MuiSvgIcon-root"
+          data-cy="icon-button-icon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+          />
+        </svg>
+      </span>
+      <span
+        className="MuiTouchRipple-root"
+      />
+    </button>
+  </span>
+</span>
+`;
+
 exports[`IconButton test suite: custom icon 1`] = `
 <button
   className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
@@ -232,59 +412,4 @@ exports[`IconButton test suite: size 1`] = `
     className="MuiTouchRipple-root"
   />
 </button>
-`;
-
-exports[`IconButton test suite: tooltip 1`] = `
-<span
-  aria-describedby={null}
-  aria-label="account"
-  className=""
-  data-cy="icon-button-tooltip"
-  onBlur={[Function]}
-  onFocus={[Function]}
-  onMouseLeave={[Function]}
-  onMouseOver={[Function]}
-  onTouchEnd={[Function]}
-  onTouchStart={[Function]}
-  title="Account"
->
-  <button
-    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-    data-cy="icon-button"
-    disabled={false}
-    onBlur={[Function]}
-    onClick={[Function]}
-    onDragLeave={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-    onTouchEnd={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
-    tabIndex={0}
-    type="button"
-  >
-    <span
-      className="MuiIconButton-label"
-    >
-      <svg
-        aria-hidden={true}
-        className="MuiSvgIcon-root"
-        data-cy="icon-button-icon"
-        focusable="false"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-        />
-      </svg>
-    </span>
-    <span
-      className="MuiTouchRipple-root"
-    />
-  </button>
-</span>
 `;

--- a/src/components/IconButton/__snapshots__/index.test.tsx.snap
+++ b/src/components/IconButton/__snapshots__/index.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`IconButton test suite: adornment - badge & tooltip 1`] = `
         />
       </button>
       <span
-        className="MuiBadge-badge MuiBadge-anchorOriginTopRightRectangle"
+        className="MuiBadge-badge MuiBadge-anchorOriginTopRightCircular"
       >
         3
       </span>
@@ -113,7 +113,7 @@ exports[`IconButton test suite: adornment - badge 1`] = `
       </span>
     </button>
     <span
-      className="MuiBadge-badge MuiBadge-anchorOriginTopRightRectangle"
+      className="MuiBadge-badge MuiBadge-anchorOriginTopRightCircular"
     >
       3
     </span>

--- a/src/components/IconButton/__snapshots__/index.test.tsx.snap
+++ b/src/components/IconButton/__snapshots__/index.test.tsx.snap
@@ -233,3 +233,58 @@ exports[`IconButton test suite: size 1`] = `
   />
 </button>
 `;
+
+exports[`IconButton test suite: tooltip 1`] = `
+<span
+  aria-describedby={null}
+  aria-label="account"
+  className=""
+  data-cy="icon-button-tooltip"
+  onBlur={[Function]}
+  onFocus={[Function]}
+  onMouseLeave={[Function]}
+  onMouseOver={[Function]}
+  onTouchEnd={[Function]}
+  onTouchStart={[Function]}
+  title="Account"
+>
+  <button
+    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+    data-cy="icon-button"
+    disabled={false}
+    onBlur={[Function]}
+    onClick={[Function]}
+    onDragLeave={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseLeave={[Function]}
+    onMouseUp={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+    tabIndex={0}
+    type="button"
+  >
+    <span
+      className="MuiIconButton-label"
+    >
+      <svg
+        aria-hidden={true}
+        className="MuiSvgIcon-root"
+        data-cy="icon-button-icon"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+        />
+      </svg>
+    </span>
+    <span
+      className="MuiTouchRipple-root"
+    />
+  </button>
+</span>
+`;

--- a/src/components/IconButton/index.stories.tsx
+++ b/src/components/IconButton/index.stories.tsx
@@ -73,10 +73,8 @@ Styled.args = {
   },
 };
 
-// export const Size = () => (
-//   <StoriesWrapper>
-//     <IconButton icon={Icons.add} size={IconSize.small} onClick={() => {}} />
-//     <IconButton icon={Icons.add} onClick={() => {}} />
-//     <IconButton icon={Icons.add} size={IconSize.large} onClick={() => {}} />
-//   </StoriesWrapper>
-// );
+export const Tooltip = Template.bind({});
+Tooltip.args = {
+  ...Primary.args,
+  tooltip: "Add",
+};

--- a/src/components/IconButton/index.stories.tsx
+++ b/src/components/IconButton/index.stories.tsx
@@ -35,6 +35,15 @@ Primary.args = {
   icon: Icons.add,
 };
 
+export const Badge = Template.bind({});
+Badge.args = {
+  ...Primary.args,
+  badge: {
+    color: "secondary",
+    value: "8",
+  },
+};
+
 export const CustomIcon = Template.bind({});
 CustomIcon.args = {
   icon: <MUIStyleIcon />,

--- a/src/components/IconButton/index.test.tsx
+++ b/src/components/IconButton/index.test.tsx
@@ -87,4 +87,18 @@ describe("IconButton test suite:", () => {
     const snapshotWrapper = renderer.create(element).toJSON();
     expect(snapshotWrapper).toMatchSnapshot();
   });
+
+  it("tooltip", () => {
+    const tooltip = "Account";
+    const { element, wrapper } = getIconButtonTestable({
+      dataCy: getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.tooltip),
+      domNode: "span",
+      props: { tooltip },
+    });
+
+    expect(wrapper.prop("title")).toEqual(tooltip);
+
+    const snapshotWrapper = renderer.create(element).toJSON();
+    expect(snapshotWrapper).toMatchSnapshot();
+  });
 });

--- a/src/components/IconButton/index.test.tsx
+++ b/src/components/IconButton/index.test.tsx
@@ -88,15 +88,67 @@ describe("IconButton test suite:", () => {
     expect(snapshotWrapper).toMatchSnapshot();
   });
 
-  it("tooltip", () => {
-    const tooltip = "Account";
+  it("adornment - badge", () => {
+    const badgeValue = "3";
+
+    const adornmentDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.adornment);
     const { element, wrapper } = getIconButtonTestable({
-      dataCy: getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.tooltip),
+      dataCy: adornmentDataCy,
+      domNode: "span",
+      props: { badge: { value: badgeValue } },
+    });
+
+    const badgeSubpartDataCy = getComposedDataCy(adornmentDataCy, SUBPARTS_MAP.badge);
+    const badgeSubpartWrapper = wrapper.find(`span[data-cy='${badgeSubpartDataCy}']`);
+    const badgeWrapper = badgeSubpartWrapper.find(`span.MuiBadge-badge`);
+    expect(badgeWrapper.text()).toEqual(badgeValue);
+
+    const snapshotWrapper = renderer.create(element).toJSON();
+    expect(snapshotWrapper).toMatchSnapshot();
+  });
+
+  it("adornment - tooltip", () => {
+    const tooltip = "Account";
+
+    const adornmentDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.adornment);
+    const { element, wrapper } = getIconButtonTestable({
+      dataCy: adornmentDataCy,
       domNode: "span",
       props: { tooltip },
     });
 
-    expect(wrapper.prop("title")).toEqual(tooltip);
+    const tooltipSubpart = getComposedDataCy(adornmentDataCy, SUBPARTS_MAP.tooltip);
+    const tooltipWrapper = wrapper.find(`span[data-cy='${tooltipSubpart}']`);
+    expect(tooltipWrapper.prop("title")).toEqual(tooltip);
+
+    const snapshotWrapper = renderer.create(element).toJSON();
+    expect(snapshotWrapper).toMatchSnapshot();
+  });
+
+  it("adornment - badge & tooltip", () => {
+    const badgeValue = "3";
+    const tooltip = "Account";
+
+    const adornmentDataCy = getComposedDataCy(DATA_CY_DEFAULT, SUBPARTS_MAP.adornment);
+    const { element, wrapper } = getIconButtonTestable({
+      dataCy: adornmentDataCy,
+      domNode: "span",
+      props: {
+        badge: {
+          value: badgeValue,
+        },
+        tooltip,
+      },
+    });
+
+    const badgeSubpartDataCy = getComposedDataCy(adornmentDataCy, SUBPARTS_MAP.badge);
+    const badgeSubpartWrapper = wrapper.find(`span[data-cy='${badgeSubpartDataCy}']`);
+    const badgeWrapper = badgeSubpartWrapper.find(`span.MuiBadge-badge`);
+    expect(badgeWrapper.text()).toEqual(badgeValue);
+
+    const tooltipSubpart = getComposedDataCy(adornmentDataCy, SUBPARTS_MAP.tooltip);
+    const tooltipWrapper = wrapper.find(`span[data-cy='${tooltipSubpart}']`);
+    expect(tooltipWrapper.prop("title")).toEqual(tooltip);
 
     const snapshotWrapper = renderer.create(element).toJSON();
     expect(snapshotWrapper).toMatchSnapshot();

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -1,22 +1,22 @@
 import React, { FC, useCallback, useMemo } from "react";
-import { IconButton as MUIIconButton, Tooltip as MUITooltip } from "@material-ui/core";
+import { IconButton as MUIIconButton } from "@material-ui/core";
 
-import { IIconButton } from "../../types/IconButton";
-import { getComposedDataCy, slugify, suppressEvent } from "../../utils";
+import { IIconButton, IIconButtonSubpart } from "../../types/IconButton";
+import { getComposedDataCy, ISubpartMap, suppressEvent } from "../../utils";
+import Adornment, { ADORNMENT_SUBPARTS } from "../Adornment";
 import IconWrapper from "../IconWrapper";
 
 export const DATA_CY_DEFAULT = "icon-button";
 
-export const SUBPARTS_MAP = {
+export const SUBPARTS_MAP: ISubpartMap<IIconButtonSubpart> = {
+  ...ADORNMENT_SUBPARTS,
   icon: {
     label: "Icon",
-  },
-  tooltip: {
-    label: "Tooltip",
   },
 };
 
 const IconButton: FC<IIconButton> = ({
+  badge,
   dataCy = DATA_CY_DEFAULT,
   icon,
   onClick,
@@ -26,6 +26,10 @@ const IconButton: FC<IIconButton> = ({
   style,
   tooltip,
 }) => {
+  const adornmentDataCy = useMemo(() => getComposedDataCy(dataCy, SUBPARTS_MAP.adornment), [dataCy]);
+
+  const iconDataCy = useMemo(() => getComposedDataCy(dataCy, SUBPARTS_MAP.icon), [dataCy]);
+
   const onClickHandler = useCallback(
     (event: any) => {
       suppressEvent(event);
@@ -34,23 +38,12 @@ const IconButton: FC<IIconButton> = ({
     [onClick]
   );
 
-  const iconButton = useMemo(
-    () => (
-      <MUIIconButton color="inherit" data-cy={dataCy} disabled={disabled} onClick={onClickHandler} style={style}>
-        <IconWrapper dataCy={getComposedDataCy(dataCy, SUBPARTS_MAP.icon)} icon={icon} rotate={rotate} size={size} />
-      </MUIIconButton>
-    ),
-    [dataCy, disabled, icon, onClickHandler, rotate, size, style]
-  );
-
-  if (!tooltip) {
-    return iconButton;
-  }
-
   return (
-    <MUITooltip aria-label={slugify(tooltip)} data-cy={getComposedDataCy(dataCy, SUBPARTS_MAP.tooltip)} title={tooltip}>
-      <span>{iconButton}</span>
-    </MUITooltip>
+    <Adornment dataCy={adornmentDataCy} badge={badge} tooltip={tooltip}>
+      <MUIIconButton color="inherit" data-cy={dataCy} disabled={disabled} onClick={onClickHandler} style={style}>
+        <IconWrapper dataCy={iconDataCy} icon={icon} rotate={rotate} size={size} />
+      </MUIIconButton>
+    </Adornment>
   );
 };
 

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useCallback } from "react";
-import MUIIconButton from "@material-ui/core/IconButton";
+import React, { FC, useCallback, useMemo } from "react";
+import { IconButton as MUIIconButton, Tooltip as MUITooltip } from "@material-ui/core";
 
 import { IIconButton } from "../../types/IconButton";
-import { getComposedDataCy, suppressEvent } from "../../utils";
+import { getComposedDataCy, slugify, suppressEvent } from "../../utils";
 import IconWrapper from "../IconWrapper";
 
 export const DATA_CY_DEFAULT = "icon-button";
@@ -21,6 +21,7 @@ const IconButton: FC<IIconButton> = ({
   rotate = false,
   size = "medium",
   style,
+  tooltip,
 }) => {
   const onClickHandler = useCallback(
     (event: any) => {
@@ -30,10 +31,23 @@ const IconButton: FC<IIconButton> = ({
     [onClick]
   );
 
+  const iconButton = useMemo(
+    () => (
+      <MUIIconButton color="inherit" data-cy={dataCy} disabled={disabled} onClick={onClickHandler} style={style}>
+        <IconWrapper dataCy={getComposedDataCy(dataCy, SUBPARTS_MAP.icon)} icon={icon} rotate={rotate} size={size} />
+      </MUIIconButton>
+    ),
+    [dataCy, disabled, icon, onClickHandler, rotate, size, style]
+  );
+
+  if (!tooltip) {
+    return iconButton;
+  }
+
   return (
-    <MUIIconButton color="inherit" data-cy={dataCy} disabled={disabled} onClick={onClickHandler} style={style}>
-      <IconWrapper dataCy={getComposedDataCy(dataCy, SUBPARTS_MAP.icon)} icon={icon} rotate={rotate} size={size} />
-    </MUIIconButton>
+    <MUITooltip aria-label={slugify(tooltip)} title={tooltip}>
+      <span>{iconButton}</span>
+    </MUITooltip>
   );
 };
 

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -11,6 +11,9 @@ export const SUBPARTS_MAP = {
   icon: {
     label: "Icon",
   },
+  tooltip: {
+    label: "Tooltip",
+  },
 };
 
 const IconButton: FC<IIconButton> = ({
@@ -45,7 +48,7 @@ const IconButton: FC<IIconButton> = ({
   }
 
   return (
-    <MUITooltip aria-label={slugify(tooltip)} title={tooltip}>
+    <MUITooltip aria-label={slugify(tooltip)} data-cy={getComposedDataCy(dataCy, SUBPARTS_MAP.tooltip)} title={tooltip}>
       <span>{iconButton}</span>
     </MUITooltip>
   );

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -13,7 +13,7 @@ const MENU_ITEMS_ANCHORING: MUIPopoverOrigin = {
   horizontal: "right",
 };
 
-const Menu: FC<IMenu> = ({ dataCy, icon: externalIcon, label, items, onItemClick, style }) => {
+const Menu: FC<IMenu> = ({ dataCy, icon: externalIcon, label, items, onItemClick, style, type = "button" }) => {
   const [anchor, setAnchor] = useState<Element | null>(null);
 
   const onClose = useCallback(() => setAnchor(null), []);
@@ -44,8 +44,8 @@ const Menu: FC<IMenu> = ({ dataCy, icon: externalIcon, label, items, onItemClick
       icon = Icons.menu;
     }
 
-    if (!label) {
-      return <IconButton dataCy={dataCy} icon={icon} onClick={onMenu} style={style} />;
+    if (type === "icon") {
+      return <IconButton dataCy={dataCy} icon={icon} onClick={onMenu} style={style} tooltip={label} />;
     }
 
     return (
@@ -57,7 +57,7 @@ const Menu: FC<IMenu> = ({ dataCy, icon: externalIcon, label, items, onItemClick
         style={style}
       />
     );
-  }, [dataCy, externalIcon, label, onMenu, style]);
+  }, [dataCy, externalIcon, label, onMenu, style, type]);
 
   return (
     <Fragment>

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -92,7 +92,7 @@ const Modal: FC<IModal> = ({
         <Typography dataCy={getComposedDataCy(dataCy, SUBPARTS_MAP.title)} variant="title">
           {title}
         </Typography>
-        {closable && <IconButton icon={Icons.close} size="small" onClick={onClose} />}
+        {closable && <IconButton icon={Icons.close} size="small" onClick={onClose} tooltip="Close" />}
       </MUIDialogTitle>
       <MUIDialogContent data-cy={getComposedDataCy(dataCy, SUBPARTS_MAP.content)} dividers>
         {children}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -92,7 +92,7 @@ const Modal: FC<IModal> = ({
         <Typography dataCy={getComposedDataCy(dataCy, SUBPARTS_MAP.title)} variant="title">
           {title}
         </Typography>
-        {closable && <IconButton icon={Icons.close} size="small" onClick={onClose} tooltip="Close" />}
+        {closable && <IconButton icon={Icons.close} size="small" onClick={onClose} />}
       </MUIDialogTitle>
       <MUIDialogContent data-cy={getComposedDataCy(dataCy, SUBPARTS_MAP.content)} dividers>
         {children}

--- a/src/components/Table/__snapshots__/index.test.tsx.snap
+++ b/src/components/Table/__snapshots__/index.test.tsx.snap
@@ -1997,7 +1997,7 @@ exports[`Table test suite: global action - disabled 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "marginLeft": "none",
+            "margin": "0 4px",
           }
         }
         tabIndex={-1}
@@ -2509,7 +2509,7 @@ exports[`Table test suite: global action 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "marginLeft": "none",
+            "margin": "0 4px",
           }
         }
         tabIndex={0}
@@ -2557,7 +2557,7 @@ exports[`Table test suite: global action 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "marginLeft": "8px",
+            "margin": "0 4px",
           }
         }
         tabIndex={0}
@@ -3032,141 +3032,195 @@ exports[`Table test suite: icon action 1`] = `
         }
       }
     >
-      <button
-        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-        data-cy="table-action-Account"
-        disabled={false}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        style={
-          Object {
-            "marginLeft": "none",
-          }
-        }
-        tabIndex={0}
-        type="button"
+      <span
+        data-cy="table-action-Account-adornment"
       >
         <span
-          className="MuiIconButton-label"
+          aria-describedby={null}
+          aria-label="account"
+          className=""
+          data-cy="table-action-Account-adornment-tooltip"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          title="Account"
         >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            data-cy="table-action-Account-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-            />
-          </svg>
-        </span>
-        <span
-          className="MuiTouchRipple-root"
-        />
-      </button>
-      <button
-        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-        data-cy="table-action-No Icon"
-        disabled={false}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        style={
-          Object {
-            "marginLeft": "8px",
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            data-cy="table-action-No Icon-icon"
-            focusable="false"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
-            />
-          </svg>
-        </span>
-        <span
-          className="MuiTouchRipple-root"
-        />
-      </button>
-      <button
-        className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-        data-cy="table-action-Custom Icon"
-        disabled={false}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onDragLeave={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-        onTouchEnd={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
-        style={
-          Object {
-            "marginLeft": "8px",
-          }
-        }
-        tabIndex={0}
-        type="button"
-      >
-        <span
-          className="MuiIconButton-label"
-        >
-          <svg
-            aria-hidden={true}
-            className="MuiSvgIcon-root"
-            data-cy="table-action-Custom Icon-icon"
-            focusable="false"
+          <button
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+            data-cy="table-action-Account"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
             style={
               Object {
-                "height": 24,
-                "width": 24,
+                "margin": "0 4px",
               }
             }
-            viewBox="0 0 24 24"
+            tabIndex={0}
+            type="button"
           >
-            <path
-              d="M2.53 19.65l1.34.56v-9.03l-2.43 5.86c-.41 1.02.08 2.19 1.09 2.61zm19.5-3.7L17.07 3.98c-.31-.75-1.04-1.21-1.81-1.23-.26 0-.53.04-.79.15L7.1 5.95c-.75.31-1.21 1.03-1.23 1.8-.01.27.04.54.15.8l4.96 11.97c.31.76 1.05 1.22 1.83 1.23.26 0 .52-.05.77-.15l7.36-3.05c1.02-.42 1.51-1.59 1.09-2.6zM7.88 8.75c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-2 11c0 1.1.9 2 2 2h1.45l-3.45-8.34v6.34z"
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                data-cy="table-action-Account-icon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
             />
-          </svg>
+          </button>
         </span>
+      </span>
+      <span
+        data-cy="table-action-No Icon-adornment"
+      >
         <span
-          className="MuiTouchRipple-root"
-        />
-      </button>
+          aria-describedby={null}
+          aria-label="no-icon"
+          className=""
+          data-cy="table-action-No Icon-adornment-tooltip"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          title="No Icon"
+        >
+          <button
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+            data-cy="table-action-No Icon"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "margin": "0 4px",
+              }
+            }
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                data-cy="table-action-No Icon-icon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
+        </span>
+      </span>
+      <span
+        data-cy="table-action-Custom Icon-adornment"
+      >
+        <span
+          aria-describedby={null}
+          aria-label="custom-icon"
+          className=""
+          data-cy="table-action-Custom Icon-adornment-tooltip"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onMouseLeave={[Function]}
+          onMouseOver={[Function]}
+          onTouchEnd={[Function]}
+          onTouchStart={[Function]}
+          title="Custom Icon"
+        >
+          <button
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+            data-cy="table-action-Custom Icon"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "margin": "0 4px",
+              }
+            }
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden={true}
+                className="MuiSvgIcon-root"
+                data-cy="table-action-Custom Icon-icon"
+                focusable="false"
+                style={
+                  Object {
+                    "height": 24,
+                    "width": 24,
+                  }
+                }
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M2.53 19.65l1.34.56v-9.03l-2.43 5.86c-.41 1.02.08 2.19 1.09 2.61zm19.5-3.7L17.07 3.98c-.31-.75-1.04-1.21-1.81-1.23-.26 0-.53.04-.79.15L7.1 5.95c-.75.31-1.21 1.03-1.23 1.8-.01.27.04.54.15.8l4.96 11.97c.31.76 1.05 1.22 1.83 1.23.26 0 .52-.05.77-.15l7.36-3.05c1.02-.42 1.51-1.59 1.09-2.6zM7.88 8.75c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-2 11c0 1.1.9 2 2 2h1.45l-3.45-8.34v6.34z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
+        </span>
+      </span>
     </div>
   </div>
   <table
@@ -4464,41 +4518,59 @@ exports[`Table test suite: row action - disabled 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-              data-cy="table-action-Account"
-              disabled={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={-1}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                  data-cy="table-action-Account"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={-1}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-                  />
-                </svg>
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -4549,41 +4621,59 @@ exports[`Table test suite: row action - disabled 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-              data-cy="table-action-Account"
-              disabled={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={-1}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                  data-cy="table-action-Account"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={-1}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-                  />
-                </svg>
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -4634,41 +4724,59 @@ exports[`Table test suite: row action - disabled 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-              data-cy="table-action-Account"
-              disabled={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={-1}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                  data-cy="table-action-Account"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={-1}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-                  />
-                </svg>
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -4719,41 +4827,59 @@ exports[`Table test suite: row action - disabled 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-              data-cy="table-action-Account"
-              disabled={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={-1}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                  data-cy="table-action-Account"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={-1}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-                  />
-                </svg>
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -4804,41 +4930,59 @@ exports[`Table test suite: row action - disabled 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-              data-cy="table-action-Account"
-              disabled={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={-1}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                  data-cy="table-action-Account"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={-1}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-                  />
-                </svg>
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -4985,41 +5129,62 @@ exports[`Table test suite: row action - disabled by data 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5070,41 +5235,62 @@ exports[`Table test suite: row action - disabled by data 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5155,41 +5341,59 @@ exports[`Table test suite: row action - disabled by data 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
-              data-cy="table-action-Account"
-              disabled={true}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={-1}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit Mui-disabled Mui-disabled"
+                  data-cy="table-action-Account"
+                  disabled={true}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={-1}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
-                  />
-                </svg>
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5240,41 +5444,62 @@ exports[`Table test suite: row action - disabled by data 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5325,41 +5550,62 @@ exports[`Table test suite: row action - disabled by data 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5739,41 +5985,62 @@ exports[`Table test suite: row action 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5824,41 +6091,62 @@ exports[`Table test suite: row action 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5909,41 +6197,62 @@ exports[`Table test suite: row action 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -5994,41 +6303,62 @@ exports[`Table test suite: row action 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -6079,41 +6409,62 @@ exports[`Table test suite: row action 1`] = `
               }
             }
           >
-            <button
-              className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
-              data-cy="table-action-Account"
-              disabled={false}
-              onBlur={[Function]}
-              onClick={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              tabIndex={0}
-              type="button"
+            <span
+              data-cy="table-action-Account-adornment"
             >
               <span
-                className="MuiIconButton-label"
+                aria-describedby={null}
+                aria-label="account"
+                className=""
+                data-cy="table-action-Account-adornment-tooltip"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                onMouseLeave={[Function]}
+                onMouseOver={[Function]}
+                onTouchEnd={[Function]}
+                onTouchStart={[Function]}
+                title="Account"
               >
-                <svg
-                  aria-hidden={true}
-                  className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                  data-cy="table-action-Account-icon"
-                  focusable="false"
-                  viewBox="0 0 24 24"
+                <button
+                  className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+                  data-cy="table-action-Account"
+                  disabled={false}
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  tabIndex={0}
+                  type="button"
                 >
-                  <path
-                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                  <span
+                    className="MuiIconButton-label"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      className="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                      data-cy="table-action-Account-icon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"
+                      />
+                    </svg>
+                  </span>
+                  <span
+                    className="MuiTouchRipple-root"
                   />
-                </svg>
+                </button>
               </span>
-            </button>
+            </span>
           </div>
         </td>
       </tr>
@@ -6406,7 +6757,7 @@ exports[`Table test suite: selection action - disabled 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "marginLeft": "none",
+            "margin": "0 4px",
           }
         }
         tabIndex={-1}
@@ -6685,7 +7036,7 @@ exports[`Table test suite: selection action - disabled by data 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "marginLeft": "none",
+            "margin": "0 4px",
           }
         }
         tabIndex={-1}
@@ -6964,7 +7315,7 @@ exports[`Table test suite: selection action 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "marginLeft": "none",
+            "margin": "0 4px",
           }
         }
         tabIndex={0}
@@ -6990,9 +7341,6 @@ exports[`Table test suite: selection action 1`] = `
           </span>
           Selection
         </span>
-        <span
-          className="MuiTouchRipple-root"
-        />
       </button>
     </div>
   </div>

--- a/src/components/Table/components/PaginationActions/index.tsx
+++ b/src/components/Table/components/PaginationActions/index.tsx
@@ -51,24 +51,28 @@ const TablePaginationActions: FC<ITablePaginationActions> = ({
         disabled={leftDisabled}
         icon={Icons.first}
         onClick={() => onPageChange(null, 0)}
+        tooltip="First"
       />
       <IconButton
         dataCy={getPaginationActionDataCy("prev")}
         disabled={leftDisabled}
         icon={Icons.left}
         onClick={() => onPageChange(null, page - 1)}
+        tooltip="Prev"
       />
       <IconButton
         dataCy={getPaginationActionDataCy("next")}
         disabled={rightDisabled}
         icon={Icons.right}
         onClick={() => onPageChange(null, page + 1)}
+        tooltip="Next"
       />
       <IconButton
         dataCy={getPaginationActionDataCy("last")}
         disabled={rightDisabled}
         icon={Icons.last}
         onClick={() => onPageChange(null, lastPage)}
+        tooltip="Last"
       />
     </div>
   );

--- a/src/components/Table/components/PaginationActions/index.tsx
+++ b/src/components/Table/components/PaginationActions/index.tsx
@@ -51,28 +51,24 @@ const TablePaginationActions: FC<ITablePaginationActions> = ({
         disabled={leftDisabled}
         icon={Icons.first}
         onClick={() => onPageChange(null, 0)}
-        tooltip="First"
       />
       <IconButton
         dataCy={getPaginationActionDataCy("prev")}
         disabled={leftDisabled}
         icon={Icons.left}
         onClick={() => onPageChange(null, page - 1)}
-        tooltip="Prev"
       />
       <IconButton
         dataCy={getPaginationActionDataCy("next")}
         disabled={rightDisabled}
         icon={Icons.right}
         onClick={() => onPageChange(null, page + 1)}
-        tooltip="Next"
       />
       <IconButton
         dataCy={getPaginationActionDataCy("last")}
         disabled={rightDisabled}
         icon={Icons.last}
         onClick={() => onPageChange(null, lastPage)}
-        tooltip="Last"
       />
     </div>
   );

--- a/src/components/Table/components/RowAction/index.tsx
+++ b/src/components/Table/components/RowAction/index.tsx
@@ -47,6 +47,7 @@ const TableRowAction: FC<ITableRowAction> = ({ action, data, dataCallbackOptions
       icon={icon}
       onClick={() => callback(data, dataCallbackOptions)}
       size="small"
+      tooltip={label}
     />
   );
 };

--- a/src/components/Table/components/Toolbar/index.tsx
+++ b/src/components/Table/components/Toolbar/index.tsx
@@ -63,7 +63,6 @@ const TableToolbar: FC<ITableToolbar> = ({
           data={selectedRowsData}
           dataCallbackOptions={dataCallbackOptions}
           dataCy={dataCy}
-          index={index}
         />
       )),
     [actions, dataCallbackOptions, dataCy, selectedRowsData]

--- a/src/components/Table/components/ToolbarAction/index.tsx
+++ b/src/components/Table/components/ToolbarAction/index.tsx
@@ -19,7 +19,6 @@ const TableToolbarAction: FC<ITableToolbarAction> = ({
   dataCy: externalDataCy,
   disabled: externalDisabled,
   icon: externalIcon,
-  index,
   label,
   position,
 }) => {
@@ -47,9 +46,9 @@ const TableToolbarAction: FC<ITableToolbarAction> = ({
     return { component: externalIcon };
   }, [externalIcon, secondary]);
 
-  const style = useMemo((): CSSProperties => ({ marginLeft: index > 0 ? "8px" : "none" }), [index]);
-
   const global = useMemo(() => position === "icon" || position === "toolbar", [position]);
+
+  const style = useMemo((): CSSProperties => ({ margin: "0 4px" }), []);
 
   const onClick = useCallback(
     () => callback(!global ? data : undefined, dataCallbackOptions),
@@ -58,7 +57,14 @@ const TableToolbarAction: FC<ITableToolbarAction> = ({
 
   if (secondary) {
     return (
-      <IconButton dataCy={dataCy} disabled={disabled} icon={icon as IIconElement} onClick={onClick} style={style} />
+      <IconButton
+        dataCy={dataCy}
+        disabled={disabled}
+        icon={icon as IIconElement}
+        onClick={onClick}
+        style={style}
+        tooltip={label}
+      />
     );
   }
 

--- a/src/types/Adornment.ts
+++ b/src/types/Adornment.ts
@@ -1,10 +1,16 @@
 import { IBase } from "./Base";
 
+export type IAdornmentBadgeSubpart = "badge";
+
+export type IAdornmentTooltipSubpart = "tooltip";
+
+export type IAdornmentSubpart = "adornment" | IAdornmentBadgeSubpart | IAdornmentTooltipSubpart;
+
 type IBadgeColor = "default" | "error" | "primary" | "secondary";
 
 type IBadgeVariant = "dot" | "standard";
 
-export interface IBadgeAdornment {
+export interface IAdornmentBadge {
   color?: IBadgeColor;
   value: string;
   variant?: IBadgeVariant;
@@ -14,7 +20,7 @@ export interface IAdornment extends IBase {
   /**
    * Badge properties
    */
-  badge?: IBadgeAdornment;
+  badge?: IAdornmentBadge;
   /**
    * Text of tooltip
    */

--- a/src/types/Adornment.ts
+++ b/src/types/Adornment.ts
@@ -8,11 +8,26 @@ export type IAdornmentSubpart = "adornment" | IAdornmentBadgeSubpart | IAdornmen
 
 type IBadgeColor = "default" | "error" | "primary" | "secondary";
 
+type IBadgeOverlap = "circular" | "rectangular";
+
 type IBadgeVariant = "dot" | "standard";
 
 export interface IAdornmentBadge {
+  /**
+   * Badge color
+   */
   color?: IBadgeColor;
+  /**
+   * Badge overlap
+   */
+  overlap?: IBadgeOverlap;
+  /**
+   * Badge content
+   */
   value: string;
+  /**
+   * Badge variant
+   */
   variant?: IBadgeVariant;
 }
 

--- a/src/types/Adornment.ts
+++ b/src/types/Adornment.ts
@@ -18,7 +18,7 @@ export interface IAdornmentBadge {
 
 export interface IAdornment extends IBase {
   /**
-   * Badge properties
+   * Badge properties: color, value, string
    */
   badge?: IAdornmentBadge;
   /**

--- a/src/types/Adornment.ts
+++ b/src/types/Adornment.ts
@@ -1,0 +1,22 @@
+import { IBase } from "./Base";
+
+type IBadgeColor = "default" | "error" | "primary" | "secondary";
+
+type IBadgeVariant = "dot" | "standard";
+
+export interface IBadgeAdornment {
+  color?: IBadgeColor;
+  value: string;
+  variant?: IBadgeVariant;
+}
+
+export interface IAdornment extends IBase {
+  /**
+   * Badge properties
+   */
+  badge?: IBadgeAdornment;
+  /**
+   * Text of tooltip
+   */
+  tooltip?: string;
+}

--- a/src/types/Icon.ts
+++ b/src/types/Icon.ts
@@ -1,5 +1,6 @@
 import { CSSProperties, ReactElement } from "react";
 
+import { IAdornment } from "./Adornment";
 import { ILoadable } from "./Base";
 
 export enum Icons {
@@ -85,7 +86,7 @@ interface IForwardedIcon {
   ref?: any;
 }
 
-export interface IIcon extends ILoadable {
+export interface IIcon extends IAdornment, ILoadable {
   /**
    * Props forwarded to svg icon
    */

--- a/src/types/IconButton.ts
+++ b/src/types/IconButton.ts
@@ -1,12 +1,10 @@
+import { IAdornment, IAdornmentSubpart } from "./Adornment";
 import { IClickable } from "./Base";
 import { IIcon, IIconUtilizer } from "./Icon";
 import { IDisablableInput } from "./Input";
 
-export interface IBaseIconButton extends IClickable, IIconUtilizer {
-  /**
-   * Text of tooltip
-   */
-  tooltip?: string;
-}
+export type IIconButtonSubpart = IAdornmentSubpart | "icon";
+
+export interface IBaseIconButton extends IAdornment, IClickable, IIconUtilizer {}
 
 export type IIconButton = IBaseIconButton & IDisablableInput & Pick<IIcon, "rotate" | "size">;

--- a/src/types/IconButton.ts
+++ b/src/types/IconButton.ts
@@ -2,6 +2,11 @@ import { IClickable } from "./Base";
 import { IIcon, IIconUtilizer } from "./Icon";
 import { IDisablableInput } from "./Input";
 
-export interface IBaseIconButton extends IClickable, IIconUtilizer {}
+export interface IBaseIconButton extends IClickable, IIconUtilizer {
+  /**
+   * Text of tooltip
+   */
+  tooltip?: string;
+}
 
 export type IIconButton = IBaseIconButton & IDisablableInput & Pick<IIcon, "rotate" | "size">;

--- a/src/types/Menu.ts
+++ b/src/types/Menu.ts
@@ -18,6 +18,8 @@ export interface IMenuItem {
   value: string;
 }
 
+export type IMenuType = "button" | "icon";
+
 export interface IMenu extends IBase, IPartialIconUtilizer {
   /**
    * List of menu items
@@ -26,9 +28,13 @@ export interface IMenu extends IBase, IPartialIconUtilizer {
   /**
    * Menu label
    */
-  label?: string;
+  label: string;
   /**
    * Callback for click events, applied to all menu items
    */
   onItemClick?: IMenuItemCallback;
+  /**
+   * Menu button type 'button' or 'icon'
+   */
+  type?: IMenuType;
 }

--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -1,6 +1,7 @@
 import { CSSProperties, ReactNode } from "react";
 import { TablePaginationProps as MUITablePaginationProps } from "@material-ui/core";
 
+import { IAdornment } from "./Adornment";
 import { IBase, ILoadable, ILocalizable } from "./Base";
 import { IPartialIconUtilizer } from "./Icon";
 
@@ -23,7 +24,7 @@ export interface ITableDataCallbackOptions {
 
 export type ITableDataCallback<T, K = any> = (data: K, options?: ITableDataCallbackOptions) => T;
 
-export interface ITableAction extends IPartialIconUtilizer {
+export interface ITableAction extends IAdornment, IPartialIconUtilizer {
   /**
    * Callback for click events on table action
    */
@@ -52,12 +53,10 @@ export interface ITableToolbarAction extends IBase, ITableAction {
    */
   data: any;
   dataCy: string;
-  // TODO#lb: add docs
-  dataCallbackOptions: ITableDataCallbackOptions;
   /**
-   * Table toolbar action index
+   * Callback options for the action triggered
    */
-  index: number;
+  dataCallbackOptions: ITableDataCallbackOptions;
 }
 
 export interface ITableColumn {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,9 +10,9 @@ export interface ISubpartSuffix {
   suffix: string;
 }
 
-export interface ISubpartMap {
-  [key: string]: ISubpart;
-}
+export type ISubpartMap<T extends string = string> = {
+  [key in T]: ISubpart;
+};
 
 export const DATA_CY_SUFFIX_SEPARATOR = "-";
 


### PR DESCRIPTION
This PR adds badge and tooltip features to existing components.
Closes: #258 #167 #169 
Natively supported by `Icon` and `IconButton`, inherited by many others (`AppBar`, `Table` etc..).

Below preview of how it will look like (_all tooltips are exposed and automatically open just for purpose of documenting_).
Native support:
![badge-tooltip 001](https://user-images.githubusercontent.com/61870694/179231030-3cd1a451-19cb-4349-bab3-ecf2dbbc156f.jpeg)

Inherited support:
![badge-tooltip 002](https://user-images.githubusercontent.com/61870694/179231035-f783fcb3-6296-44df-8cdb-9ac0548e3b9f.jpeg)

This PR requires still a bit of extra work before being merged and released due to missing tests and possible improvements / refactorings. Will be released anyhow by the end of the month in the upcoming Mosaic release.

Please share your  ideas and opinions @gabrielepolizzotto-bitrocketdev @erik18xk @erosval 
