### PR TITLE
[Table] Filter column component

### DIFF
--- a/src/components/Table/components/Head/index.tsx
+++ b/src/components/Table/components/Head/index.tsx
@@ -1,0 +1,46 @@
+import React, { CSSProperties, FC, useMemo } from "react";
+import { TableHead as MUITableHead, TableRow as MUITableRow } from "@material-ui/core";
+
+import { useMosaicContext } from "../../../../hooks/useMosaicContext";
+import { ITableHead } from "../../../../types/Table";
+import { TOOLBAR_HEIGHT, TOOLBAR_HEIGHT_MOBILE } from "../../utils";
+import TableHeadFilterCell from "../HeadFilter";
+
+const TableHead: FC<ITableHead> = ({ children, columns, dataCy, showFilters, sticky }) => {
+  const {
+    view: { mobile },
+  } = useMosaicContext();
+
+  const toolbarHeight = useMemo(() => (mobile ? TOOLBAR_HEIGHT_MOBILE : TOOLBAR_HEIGHT), [mobile]);
+
+  const headerStyle = useMemo((): CSSProperties | undefined => {
+    // mui table set sticky position at cell level (see HeadCell component).
+    // When filters row is present, we need to set sticky positioning to the whole
+    // table head in order to avoid tracking the actual height of the first header
+    // row (which can vary depending on table width and cell content length).
+
+    if (showFilters && sticky) {
+      return { top: toolbarHeight, position: "sticky", zIndex: 1 };
+    }
+    return undefined;
+  }, [showFilters, sticky, toolbarHeight]);
+
+  return (
+    <MUITableHead data-cy={dataCy} style={headerStyle}>
+      {children}
+      {showFilters && (
+        <MUITableRow>
+          {columns.map((column, index) => (
+            <TableHeadFilterCell
+              key={`column-filter-${column.path || index}`}
+              dataCy={`column-filter-${column.label || index}`}
+              column={column}
+            />
+          ))}
+        </MUITableRow>
+      )}
+    </MUITableHead>
+  );
+};
+
+export default TableHead;

--- a/src/components/Table/components/HeadFilter/index.tsx
+++ b/src/components/Table/components/HeadFilter/index.tsx
@@ -1,0 +1,44 @@
+import React, { CSSProperties, FC, useMemo } from "react";
+import { TableCell as MUITableCell, useTheme } from "@material-ui/core";
+
+import { ITableHeadFilterCell } from "../../../../types/Table";
+import { COLUMN_CHECKBOX_PATH } from "../../utils";
+
+const TableHeadFilterCell: FC<ITableHeadFilterCell> = ({ column, dataCy }) => {
+  const { path, padding, width } = column;
+
+  const theme = useTheme();
+
+  const cellPadding = useMemo(() => padding || "normal", [padding]);
+
+  const cellStyle = useMemo(() => {
+    let style: CSSProperties | undefined;
+    if (path === COLUMN_CHECKBOX_PATH) {
+      style = {
+        padding: `0 ${theme.spacing(1)}px`,
+      };
+    }
+
+    if (width) {
+      style = {
+        ...style,
+        width,
+      };
+    }
+
+    style = {
+      ...style,
+      position: "initial",
+    };
+
+    return style;
+  }, [path, theme, width]);
+
+  return (
+    <MUITableCell data-cy={dataCy} padding={cellPadding} style={cellStyle} variant="head">
+      {column.renderFilter}
+    </MUITableCell>
+  );
+};
+
+export default TableHeadFilterCell;

--- a/src/components/Table/index.stories.mdx
+++ b/src/components/Table/index.stories.mdx
@@ -1,5 +1,7 @@
 import { ArgsTable, Canvas, Meta, Preview, Story, Title } from "@storybook/addon-docs";
 
+import MUITextField from "@material-ui/core/TextField";
+
 import { Icons } from "../../types/Icon";
 import { localeDecorator } from "../../utils/mocks/LocaleMock";
 
@@ -178,6 +180,41 @@ Loading state of the table
 
 <Preview>
   <Story name="Loading" args={{ loading: true }}>
+    {Template.bind()}
+  </Story>
+</Preview>
+
+### Column Filter
+
+You can display column filters by setting `renderFilter` in columns definition. Note that `Table` does not provide any filter logic and is your responsibility to toggle `showFilters` value.
+
+<Preview>
+  <Story
+    name="ColumnFilter"
+    args={{
+      columns: [
+        { label: "Name", path: "name", renderFilter: <MUITextField type="text" label="type to filter" /> },
+        { label: "Age", path: "age" },
+      ],
+      height: 400,
+      rows: [
+        { name: "Anne", age: 35 },
+        { name: "Bruce", age: 45 },
+        { name: "Carl", age: 32 },
+        { name: "Dan", age: 26 },
+        { name: "Emily", age: 36 },
+        { name: "Fabian", age: 34 },
+        { name: "George", age: 30 },
+        { name: "Harry", age: 27 },
+        { name: "Ian", age: 39 },
+        { name: "Jack", age: 40 },
+        { name: "Ken", age: 29 },
+      ],
+      showFilters: true,
+      sticky: true,
+      title: "Column Filters (sticky)",
+    }}
+  >
     {Template.bind()}
   </Story>
 </Preview>
@@ -415,6 +452,10 @@ export interface ITableColumn {
    * Method to allow custom rendering
    */
   render?: ITableDataCallback<ReactNode>;
+  /**
+   * Method to render a filter component
+   */
+  renderFilter?: ReactNode;
   /**
    * Enables sortable state
    */

--- a/src/components/Table/index.stories.tsx
+++ b/src/components/Table/index.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable storybook/default-exports */
 
 import React from "react";
+import MUITextField from "@material-ui/core/TextField";
 import MUIStyleIcon from "@material-ui/icons/Style";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
@@ -274,4 +275,18 @@ TableLayout.args = {
   rowsTotal: 6,
   tableLayout: "auto",
   title: "Try to scroll horizontally",
+};
+
+export const ColumnFilter = Template.bind({});
+ColumnFilter.args = {
+  ...Primary.args,
+  columns: [
+    { label: "Name", path: "name", renderFilter: <MUITextField type="text" label="type to filter" /> },
+    { label: "Age", path: "age" },
+  ],
+  height: 400,
+  rows: [...Primary.args.rows!, ...Primary.args.rows!, ...Primary.args.rows!],
+  showFilters: true,
+  sticky: true,
+  title: "Column Filters (sticky)",
 };

--- a/src/components/Table/index.test.tsx
+++ b/src/components/Table/index.test.tsx
@@ -622,4 +622,54 @@ describe("Table test suite:", () => {
     expect(style).toBeDefined();
     expect(style?.overflowX).toBe("auto");
   });
+
+  it("column filters - hidden", () => {
+    const columns = [
+      { label: "Name", path: "name", renderFilter: <span>name filter</span> },
+      { label: "City", path: "city", renderFilter: <span>city filter</span> },
+      { label: "Age", path: "age" },
+    ];
+
+    const rows = [
+      { name: "Anne", age: 35, city: "Anne's city" },
+      { name: "Bruce", age: 45, city: "Bruce's city" },
+      { name: "Carl", age: 32, city: "Carl's city" },
+      { name: "Dan", age: 26, city: "Dan's city" },
+      { name: "Emily", age: 36, city: "Emily's city" },
+    ];
+
+    const { wrapper } = getTableTestable({ props: { rows, columns } });
+
+    const headRows = wrapper.find("thead tr");
+    expect(headRows.length).toBe(1);
+
+    const filterCells = wrapper.find("th[data-cy^='column-filter-']");
+    expect(filterCells.length).toBe(0);
+  });
+
+  it("column filters - visible", () => {
+    const columns = [
+      { label: "Name", path: "name", renderFilter: <span>name filter</span> },
+      { label: "City", path: "city", renderFilter: <span>city filter</span> },
+      { label: "Age", path: "age" },
+    ];
+
+    const rows = [
+      { name: "Anne", age: 35, city: "Anne's city" },
+      { name: "Bruce", age: 45, city: "Bruce's city" },
+      { name: "Carl", age: 32, city: "Carl's city" },
+      { name: "Dan", age: 26, city: "Dan's city" },
+      { name: "Emily", age: 36, city: "Emily's city" },
+    ];
+
+    const { wrapper } = getTableTestable({ props: { showFilters: true, rows, columns } });
+    const headRows = wrapper.find("thead tr");
+    expect(headRows.length).toBe(2);
+
+    const filterCells = wrapper.find("th[data-cy^='column-filter-']");
+    expect(filterCells.length).toBe(columns.length);
+
+    const spans = filterCells.find("span");
+    expect(spans.length).toBe(2);
+  });
 });

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -4,7 +4,6 @@ import {
   Table as MUITable,
   TableBody as MUITableBody,
   TableContainer as MUITableContainer,
-  TableHead as MUITableHead,
   TableRow as MUITableRow,
   useTheme,
 } from "@material-ui/core";
@@ -17,6 +16,7 @@ import Checkbox from "../Checkbox";
 import TableActionsCell from "./components/ActionsCell";
 import TableDataCell from "./components/DataCell";
 import TableEmptyState from "./components/EmptyState";
+import TableHead from "./components/Head";
 import TableHeadCell from "./components/HeadCell";
 import TableLoader from "./components/Loader";
 import TablePagination from "./components/Pagination";
@@ -75,6 +75,7 @@ const Table: FC<ITable> = ({
   rows: externalRows = [],
   rowsTotal = 0,
   selectionFilter,
+  showFilters,
   sorting: externalSorting = { path: null, ordering: null },
   sticky = false,
   style: externalStyle,
@@ -286,6 +287,11 @@ const Table: FC<ITable> = ({
     return { overflowX: "auto" };
   }, [tableLayout]);
 
+  const showHeaderFilters = useMemo(
+    () => showFilters && columns.some((column) => !!column.renderFilter),
+    [columns, showFilters]
+  );
+
   return (
     <MUITableContainer component={MUIPaper} data-cy={dataCy} style={wrapperStyle}>
       {loading && <TableLoader />}
@@ -302,7 +308,7 @@ const Table: FC<ITable> = ({
       )}
       <div style={scrollContainerStyle} data-cy={getComposedDataCy(dataCy, SUBPARTS_MAP.scrollContainer)}>
         <MUITable size="small" stickyHeader={sticky} style={{ tableLayout }}>
-          <MUITableHead>
+          <TableHead columns={columns} showFilters={showHeaderFilters} sticky={!hideHeader && sticky}>
             <MUITableRow>
               {columns.map((column, index) => (
                 <TableHeadCell
@@ -316,7 +322,7 @@ const Table: FC<ITable> = ({
                 />
               ))}
             </MUITableRow>
-          </MUITableHead>
+          </TableHead>
           <MUITableBody>
             {!loading && !externalRows.length ? (
               <TableEmptyState columns={columns.length} emptyState={emptyState} />

--- a/src/types/Table.ts
+++ b/src/types/Table.ts
@@ -77,6 +77,10 @@ export interface ITableColumn {
    */
   render?: ITableDataCallback<ReactNode>;
   /**
+   * Method to render a filter component
+   */
+  renderFilter?: ReactNode;
+  /**
    * Enables sortable state
    */
   sortable?: boolean;
@@ -101,6 +105,8 @@ export interface ITableSorting {
 
 export type ITableOnSortCallback = (path: string | null, criteria: ITableSortingCriteria) => void;
 
+export type ITableHead = IBase & Pick<ITable, "columns" | "showFilters" | "sticky">;
+
 export interface ITableHeadCell extends IBase {
   /**
    * Table column definition
@@ -124,6 +130,8 @@ export interface ITableHeadCell extends IBase {
    */
   stickyHeader: boolean;
 }
+
+export type ITableHeadFilterCell = IBase & Pick<ITableHeadCell, "column" | "dataCy">;
 
 export interface ITablePagination extends IBase {
   dataCy: string;
@@ -208,6 +216,10 @@ export type ITable = ILoadable &
      * Method to allow pre-selection of rows
      */
     selectionFilter?: ITableDataCallback<boolean>;
+    /**
+     * Show filters row (does nothing if there's no column with `renderFilter` defined)
+     */
+    showFilters?: boolean;
     /**
      * Default table sorting
      */


### PR DESCRIPTION
This PR enable passing a component to render below the table header 

![Screenshot 2022-10-28 at 16 16 13](https://user-images.githubusercontent.com/2563389/198638875-3fee23ed-a137-4ad3-a860-8d5650ce2315.png)

Filter components are specific for each column and set with the `renderFilter` attribute in columns definition:

```js
columns: [
  { label: "Name", path: "name", renderFilter: <MUITextField type="text" label="type to filter" /> },
  { label: "Age", path: "age" },
],
```

Table component doesn't provide any filter logic and filters are hidden by default. To toggle visibility simply set `showFilters` prop to  `<Table />` accordingly.    

### Warning:

When table has `sticky` header MUI set sticky position at cell level (see `<HeadCell />`).
If filters row is visible, we need to set sticky positioning to the whole table head in order to avoid tracking the actual height of the first header row (which can vary depending on table width and cell content length).

Since this changes apply only when filters are visible, backward compatibility should be preserved.

ref: https://github.com/melfore/mosaic/issues/273