### PR TITLE
Updated documentation for version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [7.6.6](https://github.com/melfore/mosaic/compare/v7.6.5...v7.6.6) (2023-06-05)
 
+### chore
+
+* 🤖 Merged `beta` channel into `master`. 
+  
+  Thanks to @erosval and @alessandrotilli for actively supporting the transition to React v18.x and MUI v5.x
+
+
 # [7.7.0-beta.2](https://github.com/melfore/mosaic/compare/v7.7.0-beta.1...v7.7.0-beta.2) (2023-05-02)
 
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
  ![Mosaic CI - Release](https://github.com/melfore/mosaic/workflows/Mosaic%20CI%20-%20Release/badge.svg) [![Mosaic CI - Release Beta](https://github.com/melfore/mosaic/actions/workflows/release-beta.yml/badge.svg)](https://github.com/melfore/mosaic/actions/workflows/release-beta.yml) ![Mosaic CI - Test](https://github.com/melfore/mosaic/workflows/Mosaic%20CI%20-%20Test/badge.svg) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
-Melfore's UI kit library based on `@mui-*`.
+Melfore's UI kit library based on `@mui/*`.
 
- <a href="https://github.com/melfore/mosaic/blob/master/CHANGELOG.md" target="_blank">**Changelog**</a> | <a href="https://github.com/melfore/mosaic/blob/master/CONTRIBUTING.md" target="_blank">**Contributing**</a> | <a href="https://github.com/melfore/mosaic/blob/master/MIGRATION.md" target="_blank">**Migration**</a> | <a href="https://melfore.github.io/mosaic/beta/" target="_blank">**Demo**</a>
+ <a href="https://github.com/melfore/mosaic/blob/master/CHANGELOG.md" target="_blank">**Changelog**</a> | <a href="https://github.com/melfore/mosaic/blob/master/CONTRIBUTING.md" target="_blank">**Contributing**</a> | <a href="https://github.com/melfore/mosaic/blob/master/MIGRATION.md" target="_blank">**Migration**</a> | <a href="https://melfore.github.io/mosaic/latest/" target="_blank">**Demo**</a>
 
-## [BETA] Getting started
+## Getting started
 
-Beta channel adds pre-release support for `react v17.x` and `@mui-* v5.x`.
+Starting from @melfore/mosaic v7.6.6 Mosaic dropped support for React < v18.x and Material UI < v5.x
 
 Add the package to your project with:
 
-`npm install @melfore/mosaic@beta`
+`npm install @melfore/mosaic`
 
 It requires these `peerDependencies` to be installed in host project:
 
@@ -33,4 +33,4 @@ Simply import a `MosaicComponent` as follows:
   import { MosaicComponent } from '@melfore/mosaic';
 ```
 
-Browse <a href="https://melfore.github.io/mosaic/beta/" target="_blank">StoryBook</a> to discover all available components.
+Browse <a href="https://melfore.github.io/mosaic/latest/" target="_blank">StoryBook</a> to discover all available components.


### PR DESCRIPTION
docs: ✏️ Updated documentation for version bump

BREAKING CHANGE: 🧨 Officially dropped support for versions of React < 18.x and MUI < 5.x