### PR TITLE
[Tabs] Renamed `labelList` into `tabList`

### DIFF
--- a/src/components/ModalWithTabs/index.tsx
+++ b/src/components/ModalWithTabs/index.tsx
@@ -34,21 +34,21 @@ export const SUBPARTS_MAP = {
 export type ModalWithTabsType = TabsType & IModal;
 
 const ModalWithTabs: FC<PropsWithChildren<ModalWithTabsType>> = ({
-  dataCy = DATA_CY_DEFAULT,
-  tabList,
-  color,
-  orientation = "vertical",
-  children,
   cancel,
+  children,
   closable = false,
+  color,
   confirm,
+  dataCy = DATA_CY_DEFAULT,
   localized = false,
   onClose,
   open = false,
+  orientation = "vertical",
   responsive,
   size,
-  title,
   style,
+  tabList,
+  title,
 }) => {
   const {
     view: { tablet: tabletView },

--- a/src/components/Tabs/index.tsx
+++ b/src/components/Tabs/index.tsx
@@ -9,10 +9,10 @@ export const DATA_CY_DEFAULT = "tabs";
 
 const Tabs: FC<TabsType> = ({
   dataCy = DATA_CY_DEFAULT,
-  tabList,
   color = "primary",
   orientation = "horizontal",
   style,
+  tabList,
 }) => {
   const [value, setValue] = React.useState(0);
 


### PR DESCRIPTION
BREAKING CHANGE: 🧨 Renamed `labelList` prop into `tabList` for Tabs. This impacts also ModalWithTabs.