### PR TITLE
ci: 🎡 bump major version for all commit types if breaking

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,6 +5,7 @@
       {
         "preset": "angular",
         "releaseRules": [
+          { "breaking": true, "release": "major" },
           { "type": "chore", "release": "patch" },
           { "type": "ci", "release": "patch" },
           { "type": "docs", "release": "patch" },


### PR DESCRIPTION
chore type commits didn't trigger a major version even with breaking change footer

BREAKING CHANGE: 🧨 bump major version for all commit types if breaking

✅ Closes: #450